### PR TITLE
Feature: Support for nodeIds as AML attribute

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -529,23 +529,13 @@ namespace MarkdownProcessor
 
             var nodeId = seq["NodeId"];
 
-            // convert numeric ids
-            if (uanode.NodeId.Contains(";i=") && uanode.NodeId != null)
+            if (uanode.DecodedNodeId.IsNullNodeId == false)
             {
-                uint.TryParse(uanode.NodeId.Split(";i=")[1], out uint convertedNodeId);
-                if (convertedNodeId != 0)
-                {
-                    ExpandedNodeId expandedNodeId = new ExpandedNodeId(convertedNodeId, myuri);
-                    Variant variant = new Variant(expandedNodeId);
-                    nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
-                }
-            }
-            //convert string ids
-            else if (uanode.NodeId.Contains(";s=") && uanode.NodeId != null)
-            {
-                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.NodeId.Split(";s=")[1], myuri);
+
+                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.DecodedNodeId, myuri);
                 Variant variant = new Variant(expandedNodeId);
                 nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
+
             }
 
             var browse = seq["BrowseName"];

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -527,6 +527,27 @@ namespace MarkdownProcessor
               baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
             string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
 
+            var nodeId = seq["NodeId"];
+
+            // convert numeric ids
+            if (uanode.NodeId.Contains(";i=") && uanode.NodeId != null)
+            {
+                uint.TryParse(uanode.NodeId.Split(";i=")[1], out uint convertedNodeId);
+                if (convertedNodeId != 0)
+                {
+                    ExpandedNodeId expandedNodeId = new ExpandedNodeId(convertedNodeId, myuri);
+                    Variant variant = new Variant(expandedNodeId);
+                    nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
+                }
+            }
+            //convert string ids
+            else if (uanode.NodeId.Contains(";s=") && uanode.NodeId != null)
+            {
+                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.NodeId.Split(";s=")[1], myuri);
+                Variant variant = new Variant(expandedNodeId);
+                nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
+            }
+
             var browse = seq["BrowseName"];
             if (browse == null)
             {

--- a/SystemTest/NodeSetFiles/TestEnums.xml
+++ b/SystemTest/NodeSetFiles/TestEnums.xml
@@ -2306,6 +2306,18 @@
             </uax:NodeId>
         </Value>
     </UAVariable>
+	<UAVariable DataType="NodeId" NodeId="ns=1;b=T3BhcXVlTm9kZUlk" BrowseName="1:OpaqueNodeIdWithActualOpaqueId" ParentNodeId="ns=1;i=5019" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>OpaqueNodeIdWithActualOpaqueId</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5019</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+		</References>
+		<Value>
+			<uax:NodeId>
+				<uax:Identifier>ns=1;b=T3BhcXVlTm9kZUlk</uax:Identifier>
+			</uax:NodeId>
+		</Value>
+	</UAVariable>
     <UAVariable DataType="NodeId" NodeId="ns=1;i=6180" BrowseName="1:GuidNodeId" ParentNodeId="ns=1;i=5019" UserAccessLevel="3" AccessLevel="3">
         <DisplayName>GuidNodeId</DisplayName>
         <References>
@@ -2331,6 +2343,19 @@
             </uax:ExpandedNodeId>
         </Value>
     </UAVariable>
+	<UAVariable DataType="ExpandedNodeId" NodeId="ns=1;i=12345" BrowseName="1:NumericNodeIdWithActualNumericId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>NumericNodeIdWithActualNumericId</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5020</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+		</References>
+		<Value>
+			<uax:ExpandedNodeId>
+				<uax:Identifier>ns=1;i=12345</uax:Identifier>
+				<!--<uax:Identifier>svr=1;nsu=http://opcfoundation.org/UA/FX/AML/TESTING/;i=12345</uax:Identifier>-->
+			</uax:ExpandedNodeId>
+		</Value>
+	</UAVariable>
     <UAVariable DataType="ExpandedNodeId" NodeId="ns=1;i=6182" BrowseName="1:StringNodeId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
         <DisplayName>StringNodeId</DisplayName>
         <References>
@@ -2344,6 +2369,19 @@
             </uax:ExpandedNodeId>
         </Value>
     </UAVariable>
+	<UAVariable DataType="ExpandedNodeId" NodeId="ns=1;s=StringNodeId" BrowseName="1:StringNodeIdWithActualStringId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>StringNodeIdWithActualStringId</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5020</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+		</References>
+		<Value>
+			<uax:ExpandedNodeId>
+				<uax:Identifier>ns=1;s=StringNodeId</uax:Identifier>
+				<!--<uax:Identifier>svr=1;nsu=http://opcfoundation.org/UA/FX/AML/TESTING/;s=StringNodeId</uax:Identifier>-->
+			</uax:ExpandedNodeId>
+		</Value>
+	</UAVariable>
     <UAVariable DataType="ExpandedNodeId" NodeId="ns=1;i=6183" BrowseName="1:GuidNodeId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
         <DisplayName>GuidNodeId</DisplayName>
         <References>
@@ -2357,6 +2395,19 @@
             </uax:ExpandedNodeId>
         </Value>
     </UAVariable>
+	<UAVariable DataType="ExpandedNodeId" NodeId="ns=1;g=0EB66E95-DCED-415F-B8EC-43ED3F0C759B" BrowseName="1:GuidNodeIdWithAcutalGuidId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>GuidNodeIdWithAcutalGuidId</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5020</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+		</References>
+		<Value>
+			<uax:ExpandedNodeId>
+				<uax:Identifier>ns=1;g=0EB66E95-DCED-415F-B8EC-43ED3F0C759B</uax:Identifier>
+				<!--<uax:Identifier>svr=1;nsu=http://opcfoundation.org/UA/FX/AML/TESTING/;g=0EB66E95-DCED-415F-B8EC-43ED3F0C759B</uax:Identifier>-->
+			</uax:ExpandedNodeId>
+		</Value>
+	</UAVariable>
     <UAVariable DataType="ExpandedNodeId" NodeId="ns=1;i=6184" BrowseName="1:OpaqueNodeId" ParentNodeId="ns=1;i=5020" UserAccessLevel="3" AccessLevel="3">
         <DisplayName>OpaqueNodeId</DisplayName>
         <References>

--- a/SystemTest/TestHelper.cs
+++ b/SystemTest/TestHelper.cs
@@ -144,7 +144,7 @@ namespace SystemTest
             int counter = 0;
             while( !opc2amlProcess.HasExited && counter < 30 )
             {
-                System.Threading.Thread.Sleep(1000);
+                System.Threading.Thread.Sleep(5000);
                 counter++;
                 if ( counter >= 30 )
                 {

--- a/SystemTest/TestNodeIds.cs
+++ b/SystemTest/TestNodeIds.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+
+using Aml.Engine.AmlObjects;
+using Aml.Engine.CAEX;
+using Aml.Engine.CAEX.Extensions;
+using Opc.Ua;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Diagnostics;
+
+namespace SystemTest
+{
+    [TestClass]
+    public class TestNodeIds
+    {
+        CAEXDocument m_document = null;
+        AutomationMLContainer m_container = null;
+
+        #region Initialize
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            if (m_document == null)
+            {
+                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
+                {
+                    if (fileInfo.Name.Equals("TestEnums.xml.amlx"))
+                    {
+                        m_container = new AutomationMLContainer(fileInfo.FullName,
+                            System.IO.FileMode.Open, FileAccess.Read);
+                        Assert.IsNotNull(m_container, "Unable to find container");
+                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
+                        Assert.IsNotNull(document, "Unable to find document");
+                        m_document = document;
+                    }
+                }
+            }
+
+            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (m_document != null)
+            {
+                m_document.Unload();
+            }
+            m_container.Dispose();
+
+        }
+
+        #endregion
+
+
+        #region Tests
+        [TestMethod]
+        [DataRow("GuidNodeIdWithAcutalGuidId", "0EB66E95-DCED-415F-B8EC-43ED3F0C759B", IdType.Guid)]
+        [DataRow("NumericNodeIdWithActualNumericId", "12345", IdType.Numeric)]
+        [DataRow("OpaqueNodeIdWithActualOpaqueId", "T3BhcXVlTm9kZUlk", IdType.Opaque)]
+        [DataRow("StringNodeIdWithActualStringId", "StringNodeId", IdType.String)]
+        public void TestNodeIdentifierTypes(string internelElemantName, string nodeId, IdType idType)
+        {
+            InternalElementType testInternalElement = findInternalElementByName(internelElemantName);
+            Assert.IsNotNull(testInternalElement, "Could not find test object");
+            var nodeIdAttribute = testInternalElement.Attribute.FirstOrDefault(childElement => childElement.Name == "NodeId");
+            Assert.IsNotNull(nodeIdAttribute, "Unable to find nodeId attribute");
+            var rootNodeIdAttribute = nodeIdAttribute.Attribute.FirstOrDefault(childElement => childElement.Name == "RootNodeId");
+            Assert.IsNotNull(rootNodeIdAttribute, "Unable to find rootNodeId attribute");
+            switch (idType)
+            {
+                case IdType.Opaque:
+                    var opaqueNodeIdAttribute = rootNodeIdAttribute.Attribute.FirstOrDefault(childElement => childElement.Name == "OpaqueId");
+                    Assert.IsNotNull(opaqueNodeIdAttribute, "Unable to find opaqueNodeId attribute");
+                    Assert.AreEqual(nodeId, opaqueNodeIdAttribute.Value.ToString(), true);
+                    break;
+
+                case IdType.String:
+                    var stringNodeIdAttribute = rootNodeIdAttribute.Attribute.FirstOrDefault(childElement => childElement.Name == "StringId");
+                    Assert.IsNotNull(stringNodeIdAttribute, "Unable to find stringNodeId attribute");
+                    Assert.AreEqual(nodeId, stringNodeIdAttribute.Value.ToString());
+                    break;
+
+                case IdType.Guid:
+                    var guidNodeIdAttribute = rootNodeIdAttribute.Attribute.FirstOrDefault(childElement => childElement.Name == "GuidId");
+                    Assert.IsNotNull(guidNodeIdAttribute, "Unable to find guidNodeId attribute");
+                    Assert.AreEqual(nodeId, guidNodeIdAttribute.Value.ToString(), true);
+                    break;
+
+                case IdType.Numeric:
+                    var numericNodeIdAttribute = rootNodeIdAttribute.Attribute.FirstOrDefault(childElement => childElement.Name == "NumericId");
+                    Assert.IsNotNull(numericNodeIdAttribute, "Unable to find numericNodeId attribute");
+                    Assert.AreEqual(nodeId, numericNodeIdAttribute.Value.ToString());
+                    break;
+            }
+        }
+        #endregion
+
+        #region Helpers
+
+        public InternalElementType? findInternalElementByName(string internelElemantName)
+        {
+            foreach (var instanceHierarchy in m_document.CAEXFile.InstanceHierarchy)
+            {
+                // browse all InternalElements deep and find element with name "FxRoot"
+                foreach (var internalElement in instanceHierarchy.Descendants<InternalElementType>())
+                {
+                    if (internalElement.Name.Equals(internelElemantName)) return internalElement;
+                }
+            }
+
+            return null;
+
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
As already discussed in the Offline Engineering group, here is the implementation for the support of nodeIds, which we use at Siemens. Please be aware that only numeric and string ids are getting converted by this business logic.