### PR TITLE
58 non root complex

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -3050,7 +3050,7 @@ namespace MarkdownProcessor
 
                     default:
                         {
-                            // Lots more work to do
+                            Debug.WriteLine( "Unhandled CreateComplexVariant " + source.Name );
                             break;
                         }
                 }

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -905,14 +905,14 @@ namespace MarkdownProcessor
                                         dataValue.SourceTimestamp );
                                     if( dataValue.SourcePicoseconds > 0 )
                                     {
-                                        AddModifyAttribute( a.Attribute, "SourcePicoseconds", "UInt32",
+                                        AddModifyAttribute( a.Attribute, "SourcePicoseconds", "UInt16",
                                             dataValue.SourcePicoseconds );
                                     }
                                     AddModifyAttribute( a.Attribute, "ServerTimestamp", "DateTime",
                                         dataValue.ServerTimestamp );
                                     if ( dataValue.ServerPicoseconds > 0 )
                                     {
-                                        AddModifyAttribute( a.Attribute, "ServerPicoseconds", "UInt32",
+                                        AddModifyAttribute( a.Attribute, "ServerPicoseconds", "UInt16",
                                             dataValue.ServerPicoseconds );
                                     }
                                 }
@@ -1147,6 +1147,10 @@ namespace MarkdownProcessor
                     {
                         foreach( KeyValuePair<string, DataTypeField> fieldReferenceType in fieldReferenceTypes )
                         {
+                            if ( xmlElement.Name.Equals( "ComprehensiveScalarType" ) && fieldReferenceType.Key.Equals( "Bool" ) )
+                            {
+                                bool wait = true;
+                            }
                             Variant fieldVariant = CreateComplexVariant( fieldReferenceType.Key, fieldReferenceType.Value, xmlElement );
                            
                             bool listOf = fieldReferenceType.Value.ValueRank >= ValueRanks.OneDimension;
@@ -2955,40 +2959,15 @@ namespace MarkdownProcessor
                     case BuiltInType.StatusCode:
                     case BuiltInType.QualifiedName:
                     case BuiltInType.LocalizedText:
-                        {
-                            XmlDecoder decoder = CreateDecoder( complexElement );
-                            Opc.Ua.TypeInfo typeInfo = null;
-                            variant = new Variant( decoder.ReadVariantContents( out typeInfo ) );
-                            decoder.Close();
-
-                            break;
-                        }
-
                     case BuiltInType.DataValue:
-                        {
-                            XmlDecoder decoder = CreateDecoder( complexElement );
-                            Opc.Ua.TypeInfo typeInfo = null;
-                            variant = new Variant( decoder.ReadVariantContents( out typeInfo ) );
-                            decoder.Close();
-
-                            break;
-                        }
-
-
                     case BuiltInType.Variant:
-                        {
-                            throw new Exception( "Should not get here" );
-                            XmlDecoder decoder = CreateDecoder( complexElement );
-                            Opc.Ua.TypeInfo typeInfo = null;
-                            variant = new Variant( decoder.ReadVariantContents( out typeInfo ) );
-                            decoder.Close();
-
-                            break;
-                        }
-
                     case BuiltInType.DiagnosticInfo:
                         {
-                            bool handleThis = true;
+                            XmlDecoder decoder = CreateDecoder( complexElement );
+                            Opc.Ua.TypeInfo typeInfo = null;
+                            variant = new Variant( decoder.ReadVariantContents( out typeInfo ) );
+                            decoder.Close();
+
                             break;
                         }
 
@@ -3112,22 +3091,11 @@ namespace MarkdownProcessor
                         case BuiltInType.StatusCode:
                         case BuiltInType.QualifiedName:
                         case BuiltInType.LocalizedText:
-                            {
-                                complexElement = document.CreateElement( baseBuiltInTypeName, xmlElement.NamespaceURI );
-                                complexElement.InnerXml = xmlElement.InnerXml;
-
-                                break;
-                            }
-
                         case BuiltInType.DataValue:
+                        case BuiltInType.DiagnosticInfo:
                             {
-                                //MarkdownProcessor.NodeSet.DataTypeField variantDefinition =
-                                //    new MarkdownProcessor.NodeSet.DataTypeField();
-                                //variantDefinition.DecodedDataType = Opc.Ua.DataTypeIds.BaseDataType;
-                                //variantDefinition.ValueRank = ValueRanks.Scalar; // I don't know this
-                                //XmlElement theValue = CreateComplexElement( "Value", variantDefinition, xmlElement );
-                                //complexElement = document.CreateElement( "uax:" + baseBuiltInTypeName, "http://opcfoundation.org/UA/2008/02/Types.xsd" );
-                                //complexElement.InnerXml = xmlElement.InnerXml;
+                                complexElement = document.CreateElement( baseBuiltInTypeName, Namespaces.OpcUaXsd );
+                                complexElement.InnerXml = xmlElement.InnerXml;
 
                                 break;
                             }
@@ -3142,13 +3110,6 @@ namespace MarkdownProcessor
 
                                     complexElement = variantDocument.DocumentElement;
                                 }
-
-                                break;
-                            }
-                        case BuiltInType.DiagnosticInfo:
-                            {
-                                //complexElement = document.CreateElement( "uax:" + baseBuiltInTypeName, "http://opcfoundation.org/UA/2008/02/Types.xsd" );
-                                //complexElement.InnerXml = xmlElement.InnerXml;
 
                                 break;
                             }

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -2998,7 +2998,53 @@ namespace MarkdownProcessor
 
                     case BuiltInType.Enumeration:
                         {
-                            bool unsure = true;
+                            string value = complexElement.InnerText;
+
+                            UADataType enumDefinition = m_modelManager.FindNode<UADataType>( typeDefinition.DecodedDataType );
+
+                            if ( enumDefinition != null && 
+                                enumDefinition.Definition != null && 
+                                enumDefinition.Definition.Field != null )
+                            {
+                              
+                                int parsedValue = -1;
+                                bool useInt = int.TryParse( value, out parsedValue );
+                                if ( !useInt )
+                                {
+                                    if ( value.Contains( '_' ) )
+                                    {
+                                        string[] parts = value.Split( '_' );
+                                        // This only works if there are three parts
+                                        if ( parts.Length == 2 )
+                                        {
+                                            useInt = int.TryParse( parts[ 1 ], out parsedValue );
+                                        }
+                                    }
+                                }
+
+                                foreach( DataTypeField dataTypeField in enumDefinition.Definition.Field )
+                                {
+                                    int createEnumValue = -1;
+                                    if( useInt )
+                                    {
+                                        if( dataTypeField.Value == parsedValue )
+                                        {
+                                            createEnumValue = dataTypeField.Value;
+                                        }
+                                    }
+                                    else if( dataTypeField.Name.Equals( value, StringComparison.OrdinalIgnoreCase ) )
+                                    {
+                                        createEnumValue = dataTypeField.Value;
+                                    }
+
+                                    if ( createEnumValue >= 0 )
+                                    {
+                                        variant = new Variant( createEnumValue );
+                                        break;
+                                    }
+                                }
+                            }
+
                             break;
                         }
 
@@ -3007,7 +3053,6 @@ namespace MarkdownProcessor
                             // Lots more work to do
                             break;
                         }
-
                 }
             }
 
@@ -3114,15 +3159,10 @@ namespace MarkdownProcessor
                                 break;
                             }
 
+                        case BuiltInType.Enumeration:
                         case BuiltInType.ExtensionObject:
                             {
                                 complexElement = xmlElement;
-                                break;
-                            }
-
-                        case BuiltInType.Enumeration:
-                            {
-                                bool unsure = true;
                                 break;
                             }
 

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -1377,9 +1377,7 @@ namespace MarkdownProcessor
             {
                 baseNode = m_modelManager.FindNodeByName(ua2xsLookup[i, ua2xslookup_uaname]);
                 if( m_modelManager.IsTypeOf( nodeId, baseNode.DecodedNodeId ) )
-                {
                     return ua2xsLookup[ i, ua2xslookup_xsname ];
-                }
             }
             return "";
         }

--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aml.Engine" Version="3.1.1" />
-    <PackageReference Include="Aml.Engine.Resources" Version="2.0.3" />
+    <PackageReference Include="Aml.Engine.Resources" Version="3.0.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.371.60" />
   </ItemGroup>
 

--- a/SystemTest/ExternalInterfaces.cs
+++ b/SystemTest/ExternalInterfaces.cs
@@ -15,51 +15,14 @@ namespace SystemTest
     public class ExternalInterfaces
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                        System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
         #region Tests
-
-
-        
 
         // This test is more about studying the file output, but has validity as a real test        
         private int LinkInternalElementDifferentCount;
         [TestMethod]
         public void DifferencesBetweenLinksAndInternalElements()
         {
+            GetDocument();
             LinkInternalElementDifferentCount = 0;
             // Walk the Instances, compare InternalElements agains the number of InternalLinks
             var instanceHierarchy = m_document.CAEXFile.InstanceHierarchy;
@@ -111,6 +74,16 @@ namespace SystemTest
         #endregion
 
         #region Helpers
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
 
         #endregion
 

--- a/SystemTest/Ids.cs
+++ b/SystemTest/Ids.cs
@@ -19,46 +19,13 @@ namespace SystemTest
     public class Ids
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                        System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
         #region Tests
 
         [TestMethod]
         public void TestForGuids()
         {
+            GetDocument();
+
             Dictionary<Guid, string> interfaces = new Dictionary<Guid, string>();
             Dictionary<Guid, string> elements = new Dictionary<Guid, string>();
 
@@ -148,6 +115,16 @@ namespace SystemTest
                 }
                 WalkInstanceHierarchy(internalElement, interfaces, elements, next);
             }
+        }
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
         }
 
         #endregion

--- a/SystemTest/InternalElements.cs
+++ b/SystemTest/InternalElements.cs
@@ -20,44 +20,6 @@ namespace SystemTest
     public class InternalElements
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
 
         #region Tests
 
@@ -67,7 +29,7 @@ namespace SystemTest
             var lookupService = LookupService.Register();
             var service = ValidatorService.Register();
 
-            IEnumerable<ValidationElement> issues = service.ValidateAll(m_document);
+            IEnumerable<ValidationElement> issues = service.ValidateAll(GetDocument());
             if (issues != null)
             {
                 Assert.AreEqual(0, issues.AliasReferenceValidationResults().Count(), "AliasReferenceValidationResults");
@@ -125,7 +87,7 @@ namespace SystemTest
         public void TestDerivedTwoState(uint objectType, uint id, uint transitionTime, uint trueState, uint falseState, string prefix = "")
         {
             string root = TestHelper.GetOpcRootName();
-            CAEXObject initialClass = m_document.FindByID(root + objectType.ToString());
+            CAEXObject initialClass = GetDocument().FindByID(root + objectType.ToString());
             SystemUnitClassType classToTest = initialClass as SystemUnitClassType;
             Assert.IsNotNull(classToTest, "Unable to retrieve class to test");
 
@@ -217,7 +179,7 @@ namespace SystemTest
                 lookup = prefix + "_" + lookup;
             }
 
-            CAEXObject initialClass = m_document.FindByID(lookup);
+            CAEXObject initialClass = GetDocument().FindByID(lookup);
             SystemUnitClassType classToTest = initialClass as SystemUnitClassType;
             Assert.IsNotNull(classToTest, "Unable to retrieve class to test");
 
@@ -244,7 +206,7 @@ namespace SystemTest
         public void TestSecurityGroupInstance()
         {
             string root = TestHelper.GetOpcRootName();
-            CAEXObject initialClass = m_document.FindByID(root +
+            CAEXObject initialClass = GetDocument().FindByID(root +
                 Opc.Ua.Objects.PublishSubscribe_SecurityGroups.ToString());
             InternalElementType classToTest = initialClass as InternalElementType;
             Assert.IsNotNull(classToTest, "Unable to retrieve class to test");
@@ -345,7 +307,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/IsAbstract.cs
+++ b/SystemTest/IsAbstract.cs
@@ -18,46 +18,8 @@ namespace SystemTest
         // Test reads the nodeset file, finds everything that should be abstract,
         // Then walks the Amlx, and verifies both that the attribute is properly set, and properly not set
         const string NodeSetFile = "Opc.Ua.NodeSet2.xml";
-
+        
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if( m_document == null )
-            {
-                foreach( FileInfo fileInfo in TestHelper.RetrieveFiles() )
-                {
-                    if( fileInfo.Name.Equals( NodeSetFile + ".amlx" ) )
-                    {
-                        m_container = new AutomationMLContainer( fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read );
-                        Assert.IsNotNull( m_container, "Unable to find container" );
-                        CAEXDocument document = CAEXDocument.LoadFromStream( m_container.RootDocumentStream() );
-                        Assert.IsNotNull( document, "Unable to find document" );
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if( m_document != null )
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
 
         Dictionary<int, string> AbstractNodeIds = new Dictionary<int, string>();
         Dictionary<int, bool> Confirm = new Dictionary<int, bool>();
@@ -76,10 +38,8 @@ namespace SystemTest
         [TestMethod]
         public void TestAllIsAbstract()
         {
-            string nodeSetFile = "Opc.Ua.NodeSet2.xml";
-
             DirectoryInfo outputDirectoryInfo = TestHelper.GetOpc2AmlDirectory();
-            FileInfo nodeSetFileInfo = new FileInfo( Path.Combine( outputDirectoryInfo.FullName, nodeSetFile ) );
+            FileInfo nodeSetFileInfo = new FileInfo( Path.Combine( outputDirectoryInfo.FullName, NodeSetFile ) );
             Assert.IsTrue( nodeSetFileInfo.Exists );
 
             #region Read nodeset
@@ -111,7 +71,7 @@ namespace SystemTest
 
             #region Walk Everything
 
-            foreach( InstanceHierarchyType type in m_document.CAEXFile.InstanceHierarchy )
+            foreach( InstanceHierarchyType type in GetDocument().CAEXFile.InstanceHierarchy )
             {
                 foreach( InternalElementType internalElement in type.InternalElement )
                 {
@@ -123,7 +83,7 @@ namespace SystemTest
                 }
             }
 
-            foreach( SystemUnitClassLibType type in m_document.CAEXFile.SystemUnitClassLib )
+            foreach( SystemUnitClassLibType type in GetDocument().CAEXFile.SystemUnitClassLib )
             {
                 CAEXEnumerable<CAEXBasicObject> descendants = type.Descendants() as CAEXEnumerable<CAEXBasicObject>;
                 if( descendants != null )
@@ -143,7 +103,7 @@ namespace SystemTest
                 }
             }
 
-            foreach( InterfaceClassLibType type in m_document.CAEXFile.InterfaceClassLib )
+            foreach( InterfaceClassLibType type in GetDocument().CAEXFile.InterfaceClassLib )
             {
                 CAEXEnumerable<CAEXBasicObject> descendants = type.Descendants() as CAEXEnumerable<CAEXBasicObject>;
                 if( descendants != null )
@@ -375,5 +335,16 @@ namespace SystemTest
 
             return numeric;
         }
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( NodeSetFile + ".amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
+
     }
 }

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -75,7 +75,121 @@
                                     </DataTypeId>
                                     <Name>
                                         <NamespaceIndex>1</NamespaceIndex>
-                                        <Name>Structure Description</Name>
+                                        <Name>Structure Description One</Name>
+                                    </Name>
+                                    <StructureDefinition>
+                                        <DefaultEncodingId>
+                                            <Identifier>i=7</Identifier>
+                                        </DefaultEncodingId>
+                                        <BaseDataType>
+                                            <Identifier>i=8</Identifier>
+                                        </BaseDataType>
+                                        <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                        <Fields>
+                                            <StructureField>
+                                                <Name>One</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Two</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=9</Identifier>
+                                                </DataType>
+                                                <ValueRank>-1</ValueRank>
+                                                <ArrayDimensions/>
+                                                <MaxStringLength>567</MaxStringLength>
+                                                <IsOptional>false</IsOptional>
+                                            </StructureField>
+                                            <StructureField>
+                                                <Name>Two</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Two</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=5</Identifier>
+                                                </DataType>
+                                                <ValueRank>1</ValueRank>
+                                                <ArrayDimensions>
+                                                    <UInt32>2</UInt32>
+                                                </ArrayDimensions>
+                                                <MaxStringLength>765</MaxStringLength>
+                                                <IsOptional>true</IsOptional>
+                                            </StructureField>
+                                        </Fields>
+                                    </StructureDefinition>
+                                </StructureDescription>
+                                <StructureDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=2;i=2223</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>2</NamespaceIndex>
+                                        <Name>Structure Description Two</Name>
+                                    </Name>
+                                    <StructureDefinition>
+                                        <DefaultEncodingId>
+                                            <Identifier>i=8</Identifier>
+                                        </DefaultEncodingId>
+                                        <BaseDataType>
+                                            <Identifier>i=9</Identifier>
+                                        </BaseDataType>
+                                        <StructureType>UnionWithSubtypedValues_4</StructureType>
+                                        <Fields>
+                                            <StructureField>
+                                                <Name>Middle One</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>One</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=11</Identifier>
+                                                </DataType>
+                                                <ValueRank>-1</ValueRank>
+                                                <ArrayDimensions/>
+                                                <MaxStringLength>678</MaxStringLength>
+                                                <IsOptional>false</IsOptional>
+                                            </StructureField>
+                                            <StructureField>
+                                                <Name>Middle Two</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Test Me</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=6</Identifier>
+                                                </DataType>
+                                                <ValueRank>1</ValueRank>
+                                                <ArrayDimensions>
+                                                    <UInt32>3</UInt32>
+                                                </ArrayDimensions>
+                                                <MaxStringLength>876</MaxStringLength>
+                                                <IsOptional>true</IsOptional>
+                                            </StructureField>
+                                            <StructureField>
+                                                <Name>Middle Three</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Three</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=11</Identifier>
+                                                </DataType>
+                                                <ValueRank>-1</ValueRank>
+                                                <ArrayDimensions/>
+                                                <MaxStringLength>678</MaxStringLength>
+                                                <IsOptional>false</IsOptional>
+                                            </StructureField>
+                                        </Fields>
+                                    </StructureDefinition>
+                                </StructureDescription>
+                                <StructureDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=1;i=2224</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>1</NamespaceIndex>
+                                        <Name>Structure Description Three</Name>
                                     </Name>
                                     <StructureDefinition>
                                         <DefaultEncodingId>

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -626,6 +626,298 @@
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
             <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
         </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=3;i=5002</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <ComprehensiveArrayType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelTwo/Types.xsd">
+                        <LevelOne>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/0/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/1/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/2/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>12345678-9012-3456-7890-123456789012</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>1</MajorVersion>
+                                        <MinorVersion>2</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element One Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>987.6543</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/3/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>24682468-2468-2468-2468-246824682468</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>3</MajorVersion>
+                                        <MinorVersion>4</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element Two Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>0</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/6/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/7/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/8/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>12345678-1234-1234-1234-123456789012</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>5</MajorVersion>
+                                        <MinorVersion>6</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element Three Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>987.6543</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+                        </LevelOne>
+                        <Int16>
+                            <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Int16>
+                            <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</Int16>
+                            <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</Int16>
+                        </Int16>
+                        <UInt16>
+                            <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">4</UInt16>
+                            <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">5</UInt16>
+                            <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">6</UInt16>
+                        </UInt16>
+                        <DateTime>
+                            <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2007-01-01T00:00:00Z</DateTime>
+                            <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2008-01-01T00:00:00Z</DateTime>
+                            <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2009-01-01T00:00:00Z</DateTime>
+                        </DateTime>
+                        <Guid>
+                            <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <String>10101010-1010-1010-1010-101010101010</String>
+                            </Guid>
+                            <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <String>11001100-1100-1100-1100-110011001100</String>
+                            </Guid>
+                            <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <String>12001200-1200-1200-1200-120012001200</String>
+                            </Guid>
+                        </Guid>
+                        <ByteString>
+                            <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTM=</ByteString>
+                            <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTQ=</ByteString>
+                            <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTU=</ByteString>
+                        </ByteString>
+                        <NodeId>
+                            <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Identifier>ns=1;i=1</Identifier>
+                            </NodeId>
+                            <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Identifier>ns=2;i=2</Identifier>
+                            </NodeId>
+                            <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Identifier>ns=3;i=3</Identifier>
+                            </NodeId>
+                        </NodeId>
+                        <StatusCode>
+                            <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Code>2147549184</Code>
+                            </StatusCode>
+                            <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Code>2147614720</Code>
+                            </StatusCode>
+                            <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Code>2147680256</Code>
+                            </StatusCode>
+                        </StatusCode>
+                        <QualifiedName>
+                            <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <NamespaceIndex>1</NamespaceIndex>
+                                <Name>One</Name>
+                            </QualifiedName>
+                            <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <NamespaceIndex>2</NamespaceIndex>
+                                <Name>Two</Name>
+                            </QualifiedName>
+                            <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <NamespaceIndex>3</NamespaceIndex>
+                                <Name>Three</Name>
+                            </QualifiedName>
+                        </QualifiedName>
+                        <LocalizedText>
+                            <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Text>One</Text>
+                            </LocalizedText>
+                            <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Text>Two</Text>
+                            </LocalizedText>
+                            <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Text>Three</Text>
+                            </LocalizedText>
+                        </LocalizedText>
+                    </ComprehensiveArrayType>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
     </UAVariable>
     <UAObject SymbolicName="http___opcfoundation_org_UA_FX_AML_TESTING_InstanceLevel" NodeId="ns=1;i=5004" BrowseName="1:http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel">
         <DisplayName>http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel</DisplayName>

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -271,6 +271,89 @@
                                     </EnumDefinition>
                                     <BuiltInType>3</BuiltInType>
                                 </EnumDescription>
+                                <EnumDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=2346</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>3</NamespaceIndex>
+                                        <Name>Another Enum Description</Name>
+                                    </Name>
+                                    <EnumDefinition>
+                                        <Fields>
+                                            <EnumField>
+                                                <Value>55</Value>
+                                                <DisplayName>
+                                                    <Text>Fifty Five</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fifty Five</Text>
+                                                </Description>
+                                                <Name>Fifty Five</Name>
+                                            </EnumField>
+                                            <EnumField>
+                                                <Value>56</Value>
+                                                <DisplayName>
+                                                    <Text>Fifty Six</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fifty Six</Text>
+                                                </Description>
+                                                <Name>Fifty Six</Name>
+                                            </EnumField>
+                                            <EnumField>
+                                                <Value>57</Value>
+                                                <DisplayName>
+                                                    <Text>Fifty Seven</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fifty Seven</Text>
+                                                </Description>
+                                                <Name>Fifty Seven</Name>
+                                            </EnumField>
+                                        </Fields>
+                                    </EnumDefinition>
+                                    <BuiltInType>4</BuiltInType>
+                                </EnumDescription>
+                                <EnumDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=2347</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>2</NamespaceIndex>
+                                        <Name>A Third Enum Description</Name>
+                                    </Name>
+                                    <EnumDefinition>
+                                        <Fields>
+                                            <EnumField>
+                                                <Value>45</Value>
+                                                <DisplayName>
+                                                    <Text>Fourty Five</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fourty Five</Text>
+                                                </Description>
+                                                <Name>Fourty Five</Name>
+                                            </EnumField>
+                                            <EnumField>
+                                                <Value>46</Value>
+                                                <DisplayName>
+                                                    <Text>Fourty Six</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fourty Six</Text>
+                                                </Description>
+                                                <Name>Fourty Six</Name>
+                                            </EnumField>
+                                        </Fields>
+                                    </EnumDefinition>
+                                    <BuiltInType>5</BuiltInType>
+                                </EnumDescription>
                             </EnumDataTypes>
                             <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                 <SimpleTypeDescription>
@@ -284,20 +367,33 @@
                                     <BaseDataType>
                                         <Identifier>i=7</Identifier>
                                     </BaseDataType>
-                                    <BuiltInType>8</BuiltInType>
+                                    <BuiltInType>7</BuiltInType>
                                 </SimpleTypeDescription>
                                 <SimpleTypeDescription>
                                     <DataTypeId>
                                         <Identifier>ns=3;i=891</Identifier>
                                     </DataTypeId>
                                     <Name>
-                                        <NamespaceIndex>0</NamespaceIndex>
+                                        <NamespaceIndex>1</NamespaceIndex>
                                         <Name>EvenMoreSimple</Name>
+                                    </Name>
+                                    <BaseDataType>
+                                        <Identifier>i=8</Identifier>
+                                    </BaseDataType>
+                                    <BuiltInType>8</BuiltInType>
+                                </SimpleTypeDescription>
+                                <SimpleTypeDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=892</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>0</NamespaceIndex>
+                                        <Name>LastSimple</Name>
                                     </Name>
                                     <BaseDataType>
                                         <Identifier>i=9</Identifier>
                                     </BaseDataType>
-                                    <BuiltInType>11</BuiltInType>
+                                    <BuiltInType>9</BuiltInType>
                                 </SimpleTypeDescription>
                             </SimpleDataTypes>
                             <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Data Set Name</Name>
@@ -310,7 +406,7 @@
                                     <Description>
                                         <Text>Field One</Text>
                                     </Description>
-                                    <FieldFlags>1</FieldFlags>
+                                    <FieldFlags>0</FieldFlags>
                                     <BuiltInType>5</BuiltInType>
                                     <DataType>
                                         <Identifier>i=5</Identifier>
@@ -351,7 +447,7 @@
                                     <Description>
                                         <Text>Field Two</Text>
                                     </Description>
-                                    <FieldFlags>0</FieldFlags>
+                                    <FieldFlags>1</FieldFlags>
                                     <BuiltInType>10</BuiltInType>
                                     <DataType>
                                         <Identifier>i=10</Identifier>
@@ -363,6 +459,50 @@
                                     <MaxStringLength>333</MaxStringLength>
                                     <DataSetFieldId>
                                         <String>12341234-1234-1234-1234-123412341234</String>
+                                    </DataSetFieldId>
+                                    <Properties>
+                                        <KeyValuePair>
+                                            <Key>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>PropertyOne</Name>
+                                            </Key>
+                                            <Value>
+                                                <Value>
+                                                    <String>PropertyOne</String>
+                                                </Value>
+                                            </Value>
+                                        </KeyValuePair>
+                                        <KeyValuePair>
+                                            <Key>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>PropertyTwo</Name>
+                                            </Key>
+                                            <Value>
+                                                <Value>
+                                                    <Int32>2</Int32>
+                                                </Value>
+                                            </Value>
+                                        </KeyValuePair>
+                                    </Properties>
+
+                                </FieldMetaData>
+                                <FieldMetaData>
+                                    <Name>Field Three</Name>
+                                    <Description>
+                                        <Text>Field Three</Text>
+                                    </Description>
+                                    <FieldFlags>0</FieldFlags>
+                                    <BuiltInType>11</BuiltInType>
+                                    <DataType>
+                                        <Identifier>i=11</Identifier>
+                                    </DataType>
+                                    <ValueRank>1</ValueRank>
+                                    <ArrayDimensions>
+                                        <UInt32>4</UInt32>
+                                    </ArrayDimensions>
+                                    <MaxStringLength>333</MaxStringLength>
+                                    <DataSetFieldId>
+                                        <String>23412341-2341-2341-2341-234123412341</String>
                                     </DataSetFieldId>
                                     <Properties/>
                                 </FieldMetaData>

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -49,7 +49,7 @@
             <Field DataType="ComprehensiveScalarType" ValueRank="1" ArrayDimensions="2" Name="ScalarAsArray"/>
         </Definition>
     </UADataType>
-    <!--<UAVariable DataType="ComprehensiveScalarType" NodeId="ns=1;i=6009" BrowseName="1:LevelOne" AccessLevel="3">
+    <UAVariable DataType="ComprehensiveScalarType" NodeId="ns=1;i=6009" BrowseName="1:LevelOne" AccessLevel="3">
         <DisplayName>LevelOne</DisplayName>
         <References>
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
@@ -64,39 +64,233 @@
                     <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
                         <DataSet>
                             <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
-                                <String>http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel</String>
+                                <String>http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/</String>
+                                <String>http://opcfoundation.org/UA/FX/AML/TESTING/LevelTwo/</String>
+                                <String>http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel/</String>
                             </Namespaces>
-                            <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                            <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                            <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                            <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">My Dataset Name</Name>
-                            <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">A Description</Description>
-                            <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                            <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <StructureDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=1;i=2222</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>1</NamespaceIndex>
+                                        <Name>Structure Description</Name>
+                                    </Name>
+                                    <StructureDefinition>
+                                        <DefaultEncodingId>
+                                            <Identifier>i=7</Identifier>
+                                        </DefaultEncodingId>
+                                        <BaseDataType>
+                                            <Identifier>i=8</Identifier>
+                                        </BaseDataType>
+                                        <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                        <Fields>
+                                            <StructureField>
+                                                <Name>One</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Two</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=9</Identifier>
+                                                </DataType>
+                                                <ValueRank>-1</ValueRank>
+                                                <ArrayDimensions/>
+                                                <MaxStringLength>567</MaxStringLength>
+                                                <IsOptional>false</IsOptional>
+                                            </StructureField>
+                                            <StructureField>
+                                                <Name>Two</Name>
+                                                <Description>
+                                                    <Locale>en-ca</Locale>
+                                                    <Text>Two</Text>
+                                                </Description>
+                                                <DataType>
+                                                    <Identifier>i=5</Identifier>
+                                                </DataType>
+                                                <ValueRank>1</ValueRank>
+                                                <ArrayDimensions>
+                                                    <UInt32>2</UInt32>
+                                                </ArrayDimensions>
+                                                <MaxStringLength>765</MaxStringLength>
+                                                <IsOptional>true</IsOptional>
+                                            </StructureField>
+                                        </Fields>
+                                    </StructureDefinition>
+                                </StructureDescription>
+                            </StructureDataTypes>
+                            <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <EnumDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=2345</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>0</NamespaceIndex>
+                                        <Name>An Enum Description</Name>
+                                    </Name>
+                                    <EnumDefinition>
+                                        <Fields>
+                                            <EnumField>
+                                                <Value>45</Value>
+                                                <DisplayName>
+                                                    <Text>Fourty Five</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fourty Five</Text>
+                                                </Description>
+                                                <Name>Fourty Five</Name>
+                                            </EnumField>
+                                            <EnumField>
+                                                <Value>46</Value>
+                                                <DisplayName>
+                                                    <Text>Fourty Six</Text>
+                                                </DisplayName>
+                                                <Description>
+                                                    <Locale>en</Locale>
+                                                    <Text>Fourty Six</Text>
+                                                </Description>
+                                                <Name>Fourty Six</Name>
+                                            </EnumField>
+                                        </Fields>
+                                    </EnumDefinition>
+                                    <BuiltInType>3</BuiltInType>
+                                </EnumDescription>
+                            </EnumDataTypes>
+                            <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <SimpleTypeDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=890</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>0</NamespaceIndex>
+                                        <Name>Simple</Name>
+                                    </Name>
+                                    <BaseDataType>
+                                        <Identifier>i=7</Identifier>
+                                    </BaseDataType>
+                                    <BuiltInType>8</BuiltInType>
+                                </SimpleTypeDescription>
+                                <SimpleTypeDescription>
+                                    <DataTypeId>
+                                        <Identifier>ns=3;i=891</Identifier>
+                                    </DataTypeId>
+                                    <Name>
+                                        <NamespaceIndex>0</NamespaceIndex>
+                                        <Name>EvenMoreSimple</Name>
+                                    </Name>
+                                    <BaseDataType>
+                                        <Identifier>i=9</Identifier>
+                                    </BaseDataType>
+                                    <BuiltInType>11</BuiltInType>
+                                </SimpleTypeDescription>
+                            </SimpleDataTypes>
+                            <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Data Set Name</Name>
+                            <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Text>Data Set Description</Text>
+                            </Description>
+                            <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <FieldMetaData>
+                                    <Name>Field One</Name>
+                                    <Description>
+                                        <Text>Field One</Text>
+                                    </Description>
+                                    <FieldFlags>1</FieldFlags>
+                                    <BuiltInType>5</BuiltInType>
+                                    <DataType>
+                                        <Identifier>i=5</Identifier>
+                                    </DataType>
+                                    <ValueRank>-1</ValueRank>
+                                    <ArrayDimensions/>
+                                    <MaxStringLength>67</MaxStringLength>
+                                    <DataSetFieldId>
+                                        <String>54325432-5432-5432-5432-543254325432</String>
+                                    </DataSetFieldId>
+                                    <Properties>
+                                        <KeyValuePair>
+                                            <Key>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>PropertyOne</Name>
+                                            </Key>
+                                            <Value>
+                                                <Value>
+                                                    <String>PropertyOne</String>
+                                                </Value>
+                                            </Value>
+                                        </KeyValuePair>
+                                        <KeyValuePair>
+                                            <Key>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>PropertyTwo</Name>
+                                            </Key>
+                                            <Value>
+                                                <Value>
+                                                    <Int32>2</Int32>
+                                                </Value>
+                                            </Value>
+                                        </KeyValuePair>
+                                    </Properties>
+                                </FieldMetaData>
+                                <FieldMetaData>
+                                    <Name>Field Two</Name>
+                                    <Description>
+                                        <Text>Field Two</Text>
+                                    </Description>
+                                    <FieldFlags>0</FieldFlags>
+                                    <BuiltInType>10</BuiltInType>
+                                    <DataType>
+                                        <Identifier>i=10</Identifier>
+                                    </DataType>
+                                    <ValueRank>1</ValueRank>
+                                    <ArrayDimensions>
+                                        <UInt32>3</UInt32>
+                                    </ArrayDimensions>
+                                    <MaxStringLength>333</MaxStringLength>
+                                    <DataSetFieldId>
+                                        <String>12341234-1234-1234-1234-123412341234</String>
+                                    </DataSetFieldId>
+                                    <Properties/>
+                                </FieldMetaData>
+                            </Fields>
                             <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
-                                <String>11111111-1111-1111-1111-111111111111</String>
+                                <String>98769876-9876-9876-9876-987698769876</String>
                             </DataSetClassId>
                             <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
-                                <MajorVersion>1234</MajorVersion>
-                                <MinorVersion>5678</MinorVersion>
+                                <MajorVersion>54</MajorVersion>
+                                <MinorVersion>32</MinorVersion>
                             </ConfigurationVersion>
                         </DataSet>
                         <PublishedData>
                             <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
-                                <Identifier>i=99990</Identifier>
+                                <Identifier>ns=1;i=987</Identifier>
                             </PublishedVariable>
                             <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">13</AttributeId>
-                            <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">222</SamplingIntervalHint>
-                            <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
-                            <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">333</DeadbandValue>
-                            <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                            <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">666</SamplingIntervalHint>
+                            <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">5</DeadbandType>
+                            <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">4</DeadbandValue>
+                            <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">4:5</IndexRange>
                             <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                 <Value>
-                                    <String>A Substitute</String>
+                                    <UInt64>123456789</UInt64>
                                 </Value>
                             </SubstituteValue>
-                            <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                            <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <QualifiedName>
+                                    <NamespaceIndex>2</NamespaceIndex>
+                                    <Name>One</Name>
+                                </QualifiedName>
+                                <QualifiedName>
+                                    <NamespaceIndex>3</NamespaceIndex>
+                                    <Name>Two</Name>
+                                </QualifiedName>
+                                <QualifiedName>
+                                    <NamespaceIndex>1</NamespaceIndex>
+                                    <Name>Three</Name>
+                                </QualifiedName>
+                            </MetaDataProperties>
                         </PublishedData>
-                        <Bool>1</Bool>
+                        <Bool>true</Bool>
                         <SByte>2</SByte>
                         <Int16>3</Int16>
                         <UInt16>4</UInt16>
@@ -106,19 +300,21 @@
                         <UInt64>8</UInt64>
                         <Float>9.1</Float>
                         <Double>10.2</Double>
-                        <String>Eleven Point Three</String>
-                        <DateTime>2012-12-12T12:12:12Z</DateTime>
+                        <String>Eleven point three</String>
+                        <DateTime>2011-12-12T00:12:12Z</DateTime>
                         <Guid>
                             <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">13131313-1313-1313-1313-131313131313</String>
                         </Guid>
                         <ByteString>MTQxNDE0MTQ=</ByteString>
-                        <XmlElement><TheFifteenthElement>Fifteen</TheFifteenthElement></XmlElement>
-                        <XmlElement><TheFifteenthElement/></XmlElement>
+                        <XmlElement>
+                            <TheFifteenthElement>Fifteen</TheFifteenthElement>
+                        </XmlElement>
                         <NodeId>
                             <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">ns=2;i=16</Identifier>
                         </NodeId>
                         <ExpandedNodeId>
-                            <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">ns=0;i=17;namespaceUri:http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel</Identifier>
+                            <!--<Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">ns=0;i=17;namespaceUri:http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel</Identifier>-->
+                            <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">ns=2;i=17</Identifier>
                         </ExpandedNodeId>
                         <StatusCode>
                             <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2149056512</Code>
@@ -131,24 +327,40 @@
                             <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Twenty</Text>
                         </LocalizedText>
                         <DataValue>
-                            <Value>
+                            <Value xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                 <Value>
                                     <Int32>12345</Int32>
                                 </Value>
                             </Value>
-                            <StatusCode>
+                            <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                 <Code>2165637120</Code>
                             </StatusCode>
-                            <SourceTimestamp>2023-09-13T14:39:08.791Z</SourceTimestamp>
-                            <ServerTimestamp>2023-09-13T14:39:08.791Z</ServerTimestamp>
+                            <SourceTimestamp xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2023-09-13T14:39:08.791Z</SourceTimestamp>
+                            <ServerTimestamp xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2023-09-13T14:39:08.791Z</ServerTimestamp>
                         </DataValue>
+
                         <DiagnosticInfo>
                             <SymbolicId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">11</SymbolicId>
                             <NamespaceUri xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">22</NamespaceUri>
                             <Locale xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">33</Locale>
                             <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">44</LocalizedText>
                             <AdditionalInfo xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Diagnostic Information</AdditionalInfo>
+                            <InnerStatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <Code>2165637121</Code>
+                            </InnerStatusCode>
+                            <InnerDiagnosticInfo xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                <SymbolicId>12</SymbolicId>
+                                <NamespaceUri>23</NamespaceUri>
+                                <Locale>34</Locale>
+                                <LocalizedText>45</LocalizedText>
+                                <AdditionalInfo>Even More Diagnostic Information</AdditionalInfo>
+                                <InnerStatusCode>
+                                    <Code>2165637122</Code>
+                                </InnerStatusCode>
+                            </InnerDiagnosticInfo>
+
                         </DiagnosticInfo>
+
                     </ComprehensiveScalarType>
                 </uax:Body>
             </uax:ExtensionObject>
@@ -160,7 +372,7 @@
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
             <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
         </References>
-    </UAVariable>-->
+    </UAVariable>
     <UAObject SymbolicName="http___opcfoundation_org_UA_FX_AML_TESTING_InstanceLevel" NodeId="ns=1;i=5004" BrowseName="1:http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel">
         <DisplayName>http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel</DisplayName>
         <References>

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -708,12 +708,443 @@
                                         <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
                                         <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
                                     </Namespaces>
-                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=1;i=2222</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>Structure Description One</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=7</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=8</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=9</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>567</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=5</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>2</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>765</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=2;i=2223</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>Structure Description Two</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=8</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=9</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>UnionWithSubtypedValues_4</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>Middle One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>One</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=11</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>678</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Middle Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Test Me</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=6</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>3</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>876</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Middle Three</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Three</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=11</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>678</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=1;i=2224</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>Structure Description Three</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=7</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=8</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=9</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>567</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=5</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>2</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>765</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                    </StructureDataTypes>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2345</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>An Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>45</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Five</Text>
+                                                        </Description>
+                                                        <Name>Fourty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>46</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Six</Text>
+                                                        </Description>
+                                                        <Name>Fourty Six</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>3</BuiltInType>
+                                        </EnumDescription>
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2346</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>3</NamespaceIndex>
+                                                <Name>Another Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>55</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Five</Text>
+                                                        </Description>
+                                                        <Name>Fifty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>56</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Six</Text>
+                                                        </Description>
+                                                        <Name>Fifty Six</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>57</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Seven</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Seven</Text>
+                                                        </Description>
+                                                        <Name>Fifty Seven</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>4</BuiltInType>
+                                        </EnumDescription>
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2347</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>A Third Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>45</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Five</Text>
+                                                        </Description>
+                                                        <Name>Fourty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>46</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Six</Text>
+                                                        </Description>
+                                                        <Name>Fourty Six</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>5</BuiltInType>
+                                        </EnumDescription>
+                                    </EnumDataTypes>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=890</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>Simple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=7</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>7</BuiltInType>
+                                        </SimpleTypeDescription>
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=891</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>EvenMoreSimple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=8</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>8</BuiltInType>
+                                        </SimpleTypeDescription>
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=892</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>LastSimple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=9</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>9</BuiltInType>
+                                        </SimpleTypeDescription>
+                                    </SimpleDataTypes>
                                     <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
                                     <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <FieldMetaData>
+                                            <Name>Field One</Name>
+                                            <Description>
+                                                <Text>Field One</Text>
+                                            </Description>
+                                            <FieldFlags>0</FieldFlags>
+                                            <BuiltInType>5</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=5</Identifier>
+                                            </DataType>
+                                            <ValueRank>-1</ValueRank>
+                                            <ArrayDimensions/>
+                                            <MaxStringLength>67</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>54325432-5432-5432-5432-543254325432</String>
+                                            </DataSetFieldId>
+                                            <Properties>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyOne</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <String>PropertyOne</String>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyTwo</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <Int32>2</Int32>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                            </Properties>
+                                        </FieldMetaData>
+                                        <FieldMetaData>
+                                            <Name>Field Two</Name>
+                                            <Description>
+                                                <Text>Field Two</Text>
+                                            </Description>
+                                            <FieldFlags>1</FieldFlags>
+                                            <BuiltInType>10</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=10</Identifier>
+                                            </DataType>
+                                            <ValueRank>1</ValueRank>
+                                            <ArrayDimensions>
+                                                <UInt32>3</UInt32>
+                                            </ArrayDimensions>
+                                            <MaxStringLength>333</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>12341234-1234-1234-1234-123412341234</String>
+                                            </DataSetFieldId>
+                                            <Properties>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>0</NamespaceIndex>
+                                                        <Name>PropertyOne</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <String>PropertyOne</String>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyTwo</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <Int32>2</Int32>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                            </Properties>
+
+                                        </FieldMetaData>
+                                        <FieldMetaData>
+                                            <Name>Field Three</Name>
+                                            <Description>
+                                                <Text>Field Three</Text>
+                                            </Description>
+                                            <FieldFlags>0</FieldFlags>
+                                            <BuiltInType>11</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=11</Identifier>
+                                            </DataType>
+                                            <ValueRank>1</ValueRank>
+                                            <ArrayDimensions>
+                                                <UInt32>4</UInt32>
+                                            </ArrayDimensions>
+                                            <MaxStringLength>333</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>23412341-2341-2341-2341-234123412341</String>
+                                            </DataSetFieldId>
+                                            <Properties/>
+                                        </FieldMetaData>
+                                    </Fields>
                                     <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                         <String>24682468-2468-2468-2468-246824682468</String>
                                     </DataSetClassId>
@@ -1084,12 +1515,443 @@
                                             <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
                                             <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
                                         </Namespaces>
-                                        <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                        <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                        <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <StructureDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=1;i=2222</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>1</NamespaceIndex>
+                                                    <Name>Structure Description One</Name>
+                                                </Name>
+                                                <StructureDefinition>
+                                                    <DefaultEncodingId>
+                                                        <Identifier>i=7</Identifier>
+                                                    </DefaultEncodingId>
+                                                    <BaseDataType>
+                                                        <Identifier>i=8</Identifier>
+                                                    </BaseDataType>
+                                                    <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                    <Fields>
+                                                        <StructureField>
+                                                            <Name>One</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Two</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=9</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>-1</ValueRank>
+                                                            <ArrayDimensions/>
+                                                            <MaxStringLength>567</MaxStringLength>
+                                                            <IsOptional>false</IsOptional>
+                                                        </StructureField>
+                                                        <StructureField>
+                                                            <Name>Two</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Two</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=5</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>1</ValueRank>
+                                                            <ArrayDimensions>
+                                                                <UInt32>2</UInt32>
+                                                            </ArrayDimensions>
+                                                            <MaxStringLength>765</MaxStringLength>
+                                                            <IsOptional>true</IsOptional>
+                                                        </StructureField>
+                                                    </Fields>
+                                                </StructureDefinition>
+                                            </StructureDescription>
+                                            <StructureDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=2;i=2223</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>2</NamespaceIndex>
+                                                    <Name>Structure Description Two</Name>
+                                                </Name>
+                                                <StructureDefinition>
+                                                    <DefaultEncodingId>
+                                                        <Identifier>i=8</Identifier>
+                                                    </DefaultEncodingId>
+                                                    <BaseDataType>
+                                                        <Identifier>i=9</Identifier>
+                                                    </BaseDataType>
+                                                    <StructureType>UnionWithSubtypedValues_4</StructureType>
+                                                    <Fields>
+                                                        <StructureField>
+                                                            <Name>Middle One</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>One</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=11</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>-1</ValueRank>
+                                                            <ArrayDimensions/>
+                                                            <MaxStringLength>678</MaxStringLength>
+                                                            <IsOptional>false</IsOptional>
+                                                        </StructureField>
+                                                        <StructureField>
+                                                            <Name>Middle Two</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Test Me</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=6</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>1</ValueRank>
+                                                            <ArrayDimensions>
+                                                                <UInt32>3</UInt32>
+                                                            </ArrayDimensions>
+                                                            <MaxStringLength>876</MaxStringLength>
+                                                            <IsOptional>true</IsOptional>
+                                                        </StructureField>
+                                                        <StructureField>
+                                                            <Name>Middle Three</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Three</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=11</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>-1</ValueRank>
+                                                            <ArrayDimensions/>
+                                                            <MaxStringLength>678</MaxStringLength>
+                                                            <IsOptional>false</IsOptional>
+                                                        </StructureField>
+                                                    </Fields>
+                                                </StructureDefinition>
+                                            </StructureDescription>
+                                            <StructureDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=1;i=2224</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>1</NamespaceIndex>
+                                                    <Name>Structure Description Three</Name>
+                                                </Name>
+                                                <StructureDefinition>
+                                                    <DefaultEncodingId>
+                                                        <Identifier>i=7</Identifier>
+                                                    </DefaultEncodingId>
+                                                    <BaseDataType>
+                                                        <Identifier>i=8</Identifier>
+                                                    </BaseDataType>
+                                                    <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                    <Fields>
+                                                        <StructureField>
+                                                            <Name>One</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Two</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=9</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>-1</ValueRank>
+                                                            <ArrayDimensions/>
+                                                            <MaxStringLength>567</MaxStringLength>
+                                                            <IsOptional>false</IsOptional>
+                                                        </StructureField>
+                                                        <StructureField>
+                                                            <Name>Two</Name>
+                                                            <Description>
+                                                                <Locale>en-ca</Locale>
+                                                                <Text>Two</Text>
+                                                            </Description>
+                                                            <DataType>
+                                                                <Identifier>i=5</Identifier>
+                                                            </DataType>
+                                                            <ValueRank>1</ValueRank>
+                                                            <ArrayDimensions>
+                                                                <UInt32>2</UInt32>
+                                                            </ArrayDimensions>
+                                                            <MaxStringLength>765</MaxStringLength>
+                                                            <IsOptional>true</IsOptional>
+                                                        </StructureField>
+                                                    </Fields>
+                                                </StructureDefinition>
+                                            </StructureDescription>
+                                        </StructureDataTypes>
+                                        <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <EnumDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=2345</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>0</NamespaceIndex>
+                                                    <Name>An Enum Description</Name>
+                                                </Name>
+                                                <EnumDefinition>
+                                                    <Fields>
+                                                        <EnumField>
+                                                            <Value>45</Value>
+                                                            <DisplayName>
+                                                                <Text>Fourty Five</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fourty Five</Text>
+                                                            </Description>
+                                                            <Name>Fourty Five</Name>
+                                                        </EnumField>
+                                                        <EnumField>
+                                                            <Value>46</Value>
+                                                            <DisplayName>
+                                                                <Text>Fourty Six</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fourty Six</Text>
+                                                            </Description>
+                                                            <Name>Fourty Six</Name>
+                                                        </EnumField>
+                                                    </Fields>
+                                                </EnumDefinition>
+                                                <BuiltInType>3</BuiltInType>
+                                            </EnumDescription>
+                                            <EnumDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=2346</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>3</NamespaceIndex>
+                                                    <Name>Another Enum Description</Name>
+                                                </Name>
+                                                <EnumDefinition>
+                                                    <Fields>
+                                                        <EnumField>
+                                                            <Value>55</Value>
+                                                            <DisplayName>
+                                                                <Text>Fifty Five</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fifty Five</Text>
+                                                            </Description>
+                                                            <Name>Fifty Five</Name>
+                                                        </EnumField>
+                                                        <EnumField>
+                                                            <Value>56</Value>
+                                                            <DisplayName>
+                                                                <Text>Fifty Six</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fifty Six</Text>
+                                                            </Description>
+                                                            <Name>Fifty Six</Name>
+                                                        </EnumField>
+                                                        <EnumField>
+                                                            <Value>57</Value>
+                                                            <DisplayName>
+                                                                <Text>Fifty Seven</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fifty Seven</Text>
+                                                            </Description>
+                                                            <Name>Fifty Seven</Name>
+                                                        </EnumField>
+                                                    </Fields>
+                                                </EnumDefinition>
+                                                <BuiltInType>4</BuiltInType>
+                                            </EnumDescription>
+                                            <EnumDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=2347</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>2</NamespaceIndex>
+                                                    <Name>A Third Enum Description</Name>
+                                                </Name>
+                                                <EnumDefinition>
+                                                    <Fields>
+                                                        <EnumField>
+                                                            <Value>45</Value>
+                                                            <DisplayName>
+                                                                <Text>Fourty Five</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fourty Five</Text>
+                                                            </Description>
+                                                            <Name>Fourty Five</Name>
+                                                        </EnumField>
+                                                        <EnumField>
+                                                            <Value>46</Value>
+                                                            <DisplayName>
+                                                                <Text>Fourty Six</Text>
+                                                            </DisplayName>
+                                                            <Description>
+                                                                <Locale>en</Locale>
+                                                                <Text>Fourty Six</Text>
+                                                            </Description>
+                                                            <Name>Fourty Six</Name>
+                                                        </EnumField>
+                                                    </Fields>
+                                                </EnumDefinition>
+                                                <BuiltInType>5</BuiltInType>
+                                            </EnumDescription>
+                                        </EnumDataTypes>
+                                        <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <SimpleTypeDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=890</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>0</NamespaceIndex>
+                                                    <Name>Simple</Name>
+                                                </Name>
+                                                <BaseDataType>
+                                                    <Identifier>i=7</Identifier>
+                                                </BaseDataType>
+                                                <BuiltInType>7</BuiltInType>
+                                            </SimpleTypeDescription>
+                                            <SimpleTypeDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=891</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>1</NamespaceIndex>
+                                                    <Name>EvenMoreSimple</Name>
+                                                </Name>
+                                                <BaseDataType>
+                                                    <Identifier>i=8</Identifier>
+                                                </BaseDataType>
+                                                <BuiltInType>8</BuiltInType>
+                                            </SimpleTypeDescription>
+                                            <SimpleTypeDescription>
+                                                <DataTypeId>
+                                                    <Identifier>ns=3;i=892</Identifier>
+                                                </DataTypeId>
+                                                <Name>
+                                                    <NamespaceIndex>0</NamespaceIndex>
+                                                    <Name>LastSimple</Name>
+                                                </Name>
+                                                <BaseDataType>
+                                                    <Identifier>i=9</Identifier>
+                                                </BaseDataType>
+                                                <BuiltInType>9</BuiltInType>
+                                            </SimpleTypeDescription>
+                                        </SimpleDataTypes>
                                         <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
                                         <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                        <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <FieldMetaData>
+                                                <Name>Field One</Name>
+                                                <Description>
+                                                    <Text>Field One</Text>
+                                                </Description>
+                                                <FieldFlags>0</FieldFlags>
+                                                <BuiltInType>5</BuiltInType>
+                                                <DataType>
+                                                    <Identifier>i=5</Identifier>
+                                                </DataType>
+                                                <ValueRank>-1</ValueRank>
+                                                <ArrayDimensions/>
+                                                <MaxStringLength>67</MaxStringLength>
+                                                <DataSetFieldId>
+                                                    <String>54325432-5432-5432-5432-543254325432</String>
+                                                </DataSetFieldId>
+                                                <Properties>
+                                                    <KeyValuePair>
+                                                        <Key>
+                                                            <NamespaceIndex>2</NamespaceIndex>
+                                                            <Name>PropertyOne</Name>
+                                                        </Key>
+                                                        <Value>
+                                                            <Value>
+                                                                <String>PropertyOne</String>
+                                                            </Value>
+                                                        </Value>
+                                                    </KeyValuePair>
+                                                    <KeyValuePair>
+                                                        <Key>
+                                                            <NamespaceIndex>2</NamespaceIndex>
+                                                            <Name>PropertyTwo</Name>
+                                                        </Key>
+                                                        <Value>
+                                                            <Value>
+                                                                <Int32>2</Int32>
+                                                            </Value>
+                                                        </Value>
+                                                    </KeyValuePair>
+                                                </Properties>
+                                            </FieldMetaData>
+                                            <FieldMetaData>
+                                                <Name>Field Two</Name>
+                                                <Description>
+                                                    <Text>Field Two</Text>
+                                                </Description>
+                                                <FieldFlags>1</FieldFlags>
+                                                <BuiltInType>10</BuiltInType>
+                                                <DataType>
+                                                    <Identifier>i=10</Identifier>
+                                                </DataType>
+                                                <ValueRank>1</ValueRank>
+                                                <ArrayDimensions>
+                                                    <UInt32>3</UInt32>
+                                                </ArrayDimensions>
+                                                <MaxStringLength>333</MaxStringLength>
+                                                <DataSetFieldId>
+                                                    <String>12341234-1234-1234-1234-123412341234</String>
+                                                </DataSetFieldId>
+                                                <Properties>
+                                                    <KeyValuePair>
+                                                        <Key>
+                                                            <NamespaceIndex>0</NamespaceIndex>
+                                                            <Name>PropertyOne</Name>
+                                                        </Key>
+                                                        <Value>
+                                                            <Value>
+                                                                <String>PropertyOne</String>
+                                                            </Value>
+                                                        </Value>
+                                                    </KeyValuePair>
+                                                    <KeyValuePair>
+                                                        <Key>
+                                                            <NamespaceIndex>2</NamespaceIndex>
+                                                            <Name>PropertyTwo</Name>
+                                                        </Key>
+                                                        <Value>
+                                                            <Value>
+                                                                <Int32>2</Int32>
+                                                            </Value>
+                                                        </Value>
+                                                    </KeyValuePair>
+                                                </Properties>
+
+                                            </FieldMetaData>
+                                            <FieldMetaData>
+                                                <Name>Field Three</Name>
+                                                <Description>
+                                                    <Text>Field Three</Text>
+                                                </Description>
+                                                <FieldFlags>0</FieldFlags>
+                                                <BuiltInType>11</BuiltInType>
+                                                <DataType>
+                                                    <Identifier>i=11</Identifier>
+                                                </DataType>
+                                                <ValueRank>1</ValueRank>
+                                                <ArrayDimensions>
+                                                    <UInt32>4</UInt32>
+                                                </ArrayDimensions>
+                                                <MaxStringLength>333</MaxStringLength>
+                                                <DataSetFieldId>
+                                                    <String>23412341-2341-2341-2341-234123412341</String>
+                                                </DataSetFieldId>
+                                                <Properties/>
+                                            </FieldMetaData>
+                                        </Fields>
                                         <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                             <String>24682468-2468-2468-2468-246824682468</String>
                                         </DataSetClassId>
@@ -1366,12 +2228,443 @@
                                         <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
                                         <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
                                     </Namespaces>
-                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=1;i=2222</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>Structure Description One</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=7</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=8</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=9</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>567</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=5</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>2</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>765</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=2;i=2223</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>Structure Description Two</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=8</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=9</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>UnionWithSubtypedValues_4</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>Middle One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>One</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=11</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>678</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Middle Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Test Me</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=6</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>3</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>876</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Middle Three</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Three</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=11</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>678</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                        <StructureDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=1;i=2224</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>Structure Description Three</Name>
+                                            </Name>
+                                            <StructureDefinition>
+                                                <DefaultEncodingId>
+                                                    <Identifier>i=7</Identifier>
+                                                </DefaultEncodingId>
+                                                <BaseDataType>
+                                                    <Identifier>i=8</Identifier>
+                                                </BaseDataType>
+                                                <StructureType>StructureWithSubtypedValues_3</StructureType>
+                                                <Fields>
+                                                    <StructureField>
+                                                        <Name>One</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=9</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>-1</ValueRank>
+                                                        <ArrayDimensions/>
+                                                        <MaxStringLength>567</MaxStringLength>
+                                                        <IsOptional>false</IsOptional>
+                                                    </StructureField>
+                                                    <StructureField>
+                                                        <Name>Two</Name>
+                                                        <Description>
+                                                            <Locale>en-ca</Locale>
+                                                            <Text>Two</Text>
+                                                        </Description>
+                                                        <DataType>
+                                                            <Identifier>i=5</Identifier>
+                                                        </DataType>
+                                                        <ValueRank>1</ValueRank>
+                                                        <ArrayDimensions>
+                                                            <UInt32>2</UInt32>
+                                                        </ArrayDimensions>
+                                                        <MaxStringLength>765</MaxStringLength>
+                                                        <IsOptional>true</IsOptional>
+                                                    </StructureField>
+                                                </Fields>
+                                            </StructureDefinition>
+                                        </StructureDescription>
+                                    </StructureDataTypes>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2345</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>An Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>45</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Five</Text>
+                                                        </Description>
+                                                        <Name>Fourty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>46</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Six</Text>
+                                                        </Description>
+                                                        <Name>Fourty Six</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>3</BuiltInType>
+                                        </EnumDescription>
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2346</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>3</NamespaceIndex>
+                                                <Name>Another Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>55</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Five</Text>
+                                                        </Description>
+                                                        <Name>Fifty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>56</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Six</Text>
+                                                        </Description>
+                                                        <Name>Fifty Six</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>57</Value>
+                                                        <DisplayName>
+                                                            <Text>Fifty Seven</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fifty Seven</Text>
+                                                        </Description>
+                                                        <Name>Fifty Seven</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>4</BuiltInType>
+                                        </EnumDescription>
+                                        <EnumDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=2347</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>2</NamespaceIndex>
+                                                <Name>A Third Enum Description</Name>
+                                            </Name>
+                                            <EnumDefinition>
+                                                <Fields>
+                                                    <EnumField>
+                                                        <Value>45</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Five</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Five</Text>
+                                                        </Description>
+                                                        <Name>Fourty Five</Name>
+                                                    </EnumField>
+                                                    <EnumField>
+                                                        <Value>46</Value>
+                                                        <DisplayName>
+                                                            <Text>Fourty Six</Text>
+                                                        </DisplayName>
+                                                        <Description>
+                                                            <Locale>en</Locale>
+                                                            <Text>Fourty Six</Text>
+                                                        </Description>
+                                                        <Name>Fourty Six</Name>
+                                                    </EnumField>
+                                                </Fields>
+                                            </EnumDefinition>
+                                            <BuiltInType>5</BuiltInType>
+                                        </EnumDescription>
+                                    </EnumDataTypes>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=890</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>Simple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=7</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>7</BuiltInType>
+                                        </SimpleTypeDescription>
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=891</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>1</NamespaceIndex>
+                                                <Name>EvenMoreSimple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=8</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>8</BuiltInType>
+                                        </SimpleTypeDescription>
+                                        <SimpleTypeDescription>
+                                            <DataTypeId>
+                                                <Identifier>ns=3;i=892</Identifier>
+                                            </DataTypeId>
+                                            <Name>
+                                                <NamespaceIndex>0</NamespaceIndex>
+                                                <Name>LastSimple</Name>
+                                            </Name>
+                                            <BaseDataType>
+                                                <Identifier>i=9</Identifier>
+                                            </BaseDataType>
+                                            <BuiltInType>9</BuiltInType>
+                                        </SimpleTypeDescription>
+                                    </SimpleDataTypes>
                                     <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
                                     <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
-                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <FieldMetaData>
+                                            <Name>Field One</Name>
+                                            <Description>
+                                                <Text>Field One</Text>
+                                            </Description>
+                                            <FieldFlags>0</FieldFlags>
+                                            <BuiltInType>5</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=5</Identifier>
+                                            </DataType>
+                                            <ValueRank>-1</ValueRank>
+                                            <ArrayDimensions/>
+                                            <MaxStringLength>67</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>54325432-5432-5432-5432-543254325432</String>
+                                            </DataSetFieldId>
+                                            <Properties>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyOne</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <String>PropertyOne</String>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyTwo</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <Int32>2</Int32>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                            </Properties>
+                                        </FieldMetaData>
+                                        <FieldMetaData>
+                                            <Name>Field Two</Name>
+                                            <Description>
+                                                <Text>Field Two</Text>
+                                            </Description>
+                                            <FieldFlags>1</FieldFlags>
+                                            <BuiltInType>10</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=10</Identifier>
+                                            </DataType>
+                                            <ValueRank>1</ValueRank>
+                                            <ArrayDimensions>
+                                                <UInt32>3</UInt32>
+                                            </ArrayDimensions>
+                                            <MaxStringLength>333</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>12341234-1234-1234-1234-123412341234</String>
+                                            </DataSetFieldId>
+                                            <Properties>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>0</NamespaceIndex>
+                                                        <Name>PropertyOne</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <String>PropertyOne</String>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                                <KeyValuePair>
+                                                    <Key>
+                                                        <NamespaceIndex>2</NamespaceIndex>
+                                                        <Name>PropertyTwo</Name>
+                                                    </Key>
+                                                    <Value>
+                                                        <Value>
+                                                            <Int32>2</Int32>
+                                                        </Value>
+                                                    </Value>
+                                                </KeyValuePair>
+                                            </Properties>
+
+                                        </FieldMetaData>
+                                        <FieldMetaData>
+                                            <Name>Field Three</Name>
+                                            <Description>
+                                                <Text>Field Three</Text>
+                                            </Description>
+                                            <FieldFlags>0</FieldFlags>
+                                            <BuiltInType>11</BuiltInType>
+                                            <DataType>
+                                                <Identifier>i=11</Identifier>
+                                            </DataType>
+                                            <ValueRank>1</ValueRank>
+                                            <ArrayDimensions>
+                                                <UInt32>4</UInt32>
+                                            </ArrayDimensions>
+                                            <MaxStringLength>333</MaxStringLength>
+                                            <DataSetFieldId>
+                                                <String>23412341-2341-2341-2341-234123412341</String>
+                                            </DataSetFieldId>
+                                            <Properties/>
+                                        </FieldMetaData>
+                                    </Fields>
                                     <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
                                         <String>24682468-2468-2468-2468-246824682468</String>
                                     </DataSetClassId>
@@ -1952,7 +3245,7 @@
                                     <uax:Name>anothername</uax:Name>
                                 </uax:QualifiedName>
                             </uax:MetaDataProperties>
-                    </uax:PublishedVariableDataType>
+                        </uax:PublishedVariableDataType>
                     </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>

--- a/SystemTest/NodeSetFiles/InstanceLevel.xml
+++ b/SystemTest/NodeSetFiles/InstanceLevel.xml
@@ -994,13 +994,517 @@
             <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5004</Reference>
         </References>
     </UAVariable>
-    <!--<UAVariable DataType="ComplexComprehensiveType" NodeId="ns=1;i=6013" BrowseName="1:TopLevel" AccessLevel="3">
+
+    <UAVariable DataType="ComplexComprehensiveType" NodeId="ns=1;i=6013" BrowseName="1:TopLevel" AccessLevel="3">
         <DisplayName>TopLevel</DisplayName>
         <References>
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
             <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
         </References>
-    </UAVariable>-->
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=5002</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <ComplexComprehensiveType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/InstanceLevel/Types.xsd">
+                        <ArrayAsScalar>
+                            <LevelOne>
+                                <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                    <DataSet>
+                                        <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/0/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/1/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/2/</String>
+                                        </Namespaces>
+                                        <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                        <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>12345678-9012-3456-7890-123456789012</String>
+                                        </DataSetClassId>
+                                        <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <MajorVersion>1</MajorVersion>
+                                            <MinorVersion>2</MinorVersion>
+                                        </ConfigurationVersion>
+                                    </DataSet>
+                                    <PublishedData>
+                                        <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Identifier>i=0</Identifier>
+                                        </PublishedVariable>
+                                        <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                        <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                        <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                        <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                        <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                        <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Value>
+                                                <String>Array Element One Substitute</String>
+                                            </Value>
+                                        </SubstituteValue>
+                                        <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    </PublishedData>
+                                    <Bool>false</Bool>
+                                    <SByte>0</SByte>
+                                    <Int16>0</Int16>
+                                    <UInt16>0</UInt16>
+                                    <Int32>0</Int32>
+                                    <UInt32>0</UInt32>
+                                    <Int64>0</Int64>
+                                    <UInt64>0</UInt64>
+                                    <Float>0</Float>
+                                    <Double>987.6543</Double>
+                                    <String></String>
+                                    <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                    <Guid>
+                                        <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                    </Guid>
+                                    <ByteString></ByteString>
+                                    <NodeId>
+                                        <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                    </NodeId>
+                                    <StatusCode>
+                                        <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                    </StatusCode>
+                                    <QualifiedName>
+                                        <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Name>
+                                    </QualifiedName>
+                                    <LocalizedText>
+                                        <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Text>
+                                    </LocalizedText>
+                                </ComprehensiveScalarType>
+                                <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                    <DataSet>
+                                        <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/3/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
+                                        </Namespaces>
+                                        <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                        <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>24682468-2468-2468-2468-246824682468</String>
+                                        </DataSetClassId>
+                                        <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <MajorVersion>3</MajorVersion>
+                                            <MinorVersion>4</MinorVersion>
+                                        </ConfigurationVersion>
+                                    </DataSet>
+                                    <PublishedData>
+                                        <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Identifier>i=0</Identifier>
+                                        </PublishedVariable>
+                                        <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                        <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                        <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                        <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                        <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                        <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Value>
+                                                <String>Array Element Two Substitute</String>
+                                            </Value>
+                                        </SubstituteValue>
+                                        <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    </PublishedData>
+                                    <Bool>false</Bool>
+                                    <SByte>0</SByte>
+                                    <Int16>0</Int16>
+                                    <UInt16>0</UInt16>
+                                    <Int32>0</Int32>
+                                    <UInt32>0</UInt32>
+                                    <Int64>0</Int64>
+                                    <UInt64>0</UInt64>
+                                    <Float>0</Float>
+                                    <Double>0</Double>
+                                    <String></String>
+                                    <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                    <Guid>
+                                        <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                    </Guid>
+                                    <ByteString></ByteString>
+                                    <NodeId>
+                                        <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                    </NodeId>
+                                    <StatusCode>
+                                        <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                    </StatusCode>
+                                    <QualifiedName>
+                                        <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Name>
+                                    </QualifiedName>
+                                    <LocalizedText>
+                                        <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Text>
+                                    </LocalizedText>
+                                </ComprehensiveScalarType>
+                                <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                    <DataSet>
+                                        <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/6/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/7/</String>
+                                            <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/8/</String>
+                                        </Namespaces>
+                                        <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                        <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                        <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <String>12345678-1234-1234-1234-123456789012</String>
+                                        </DataSetClassId>
+                                        <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <MajorVersion>5</MajorVersion>
+                                            <MinorVersion>6</MinorVersion>
+                                        </ConfigurationVersion>
+                                    </DataSet>
+                                    <PublishedData>
+                                        <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Identifier>i=0</Identifier>
+                                        </PublishedVariable>
+                                        <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                        <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                        <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                        <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                        <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                        <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                            <Value>
+                                                <String>Array Element Three Substitute</String>
+                                            </Value>
+                                        </SubstituteValue>
+                                        <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    </PublishedData>
+                                    <Bool>false</Bool>
+                                    <SByte>0</SByte>
+                                    <Int16>0</Int16>
+                                    <UInt16>0</UInt16>
+                                    <Int32>0</Int32>
+                                    <UInt32>0</UInt32>
+                                    <Int64>0</Int64>
+                                    <UInt64>0</UInt64>
+                                    <Float>0</Float>
+                                    <Double>987.6543</Double>
+                                    <String></String>
+                                    <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                    <Guid>
+                                        <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                    </Guid>
+                                    <ByteString></ByteString>
+                                    <NodeId>
+                                        <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                    </NodeId>
+                                    <StatusCode>
+                                        <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                    </StatusCode>
+                                    <QualifiedName>
+                                        <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                        <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Name>
+                                    </QualifiedName>
+                                    <LocalizedText>
+                                        <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Text>
+                                    </LocalizedText>
+                                </ComprehensiveScalarType>
+                            </LevelOne>
+                            <Int16>
+                                <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Int16>
+                                <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</Int16>
+                                <Int16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</Int16>
+                            </Int16>
+                            <UInt16>
+                                <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">4</UInt16>
+                                <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">5</UInt16>
+                                <UInt16 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">6</UInt16>
+                            </UInt16>
+                            <DateTime>
+                                <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2007-01-01T00:00:00Z</DateTime>
+                                <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2008-01-01T00:00:00Z</DateTime>
+                                <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2009-01-01T00:00:00Z</DateTime>
+                            </DateTime>
+                            <Guid>
+                                <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <String>10101010-1010-1010-1010-101010101010</String>
+                                </Guid>
+                                <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <String>11001100-1100-1100-1100-110011001100</String>
+                                </Guid>
+                                <Guid xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <String>12001200-1200-1200-1200-120012001200</String>
+                                </Guid>
+                            </Guid>
+                            <ByteString>
+                                <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTM=</ByteString>
+                                <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTQ=</ByteString>
+                                <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">MTU=</ByteString>
+                            </ByteString>
+                            <NodeId>
+                                <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Identifier>ns=1;i=1</Identifier>
+                                </NodeId>
+                                <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Identifier>ns=2;i=2</Identifier>
+                                </NodeId>
+                                <NodeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Identifier>ns=3;i=3</Identifier>
+                                </NodeId>
+                            </NodeId>
+                            <StatusCode>
+                                <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Code>2147549184</Code>
+                                </StatusCode>
+                                <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Code>2147614720</Code>
+                                </StatusCode>
+                                <StatusCode xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Code>2147680256</Code>
+                                </StatusCode>
+                            </StatusCode>
+                            <QualifiedName>
+                                <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <NamespaceIndex>1</NamespaceIndex>
+                                    <Name>One</Name>
+                                </QualifiedName>
+                                <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <NamespaceIndex>2</NamespaceIndex>
+                                    <Name>Two</Name>
+                                </QualifiedName>
+                                <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <NamespaceIndex>3</NamespaceIndex>
+                                    <Name>Three</Name>
+                                </QualifiedName>
+                            </QualifiedName>
+                            <LocalizedText>
+                                <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Text>One</Text>
+                                </LocalizedText>
+                                <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Text>Two</Text>
+                                </LocalizedText>
+                                <LocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                    <Text>Three</Text>
+                                </LocalizedText>
+                            </LocalizedText>
+                        </ArrayAsScalar>
+                        <ScalarAsArray>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/0/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/1/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/2/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>12345678-9012-3456-7890-123456789012</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>1</MajorVersion>
+                                        <MinorVersion>2</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element One Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>987.6543</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element One</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/3/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/5/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>24682468-2468-2468-2468-246824682468</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>3</MajorVersion>
+                                        <MinorVersion>4</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element Two Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>0</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Two</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+                            <ComprehensiveScalarType xmlns="http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd">
+                                <DataSet>
+                                    <Namespaces xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/6/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/7/</String>
+                                        <String>http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/8/</String>
+                                    </Namespaces>
+                                    <StructureDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <EnumDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <SimpleDataTypes xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></Name>
+                                    <Description xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <Fields xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                    <DataSetClassId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <String>12345678-1234-1234-1234-123456789012</String>
+                                    </DataSetClassId>
+                                    <ConfigurationVersion xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <MajorVersion>5</MajorVersion>
+                                        <MinorVersion>6</MinorVersion>
+                                    </ConfigurationVersion>
+                                </DataSet>
+                                <PublishedData>
+                                    <PublishedVariable xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Identifier>i=0</Identifier>
+                                    </PublishedVariable>
+                                    <AttributeId xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</AttributeId>
+                                    <SamplingIntervalHint xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</SamplingIntervalHint>
+                                    <DeadbandType xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandType>
+                                    <DeadbandValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</DeadbandValue>
+                                    <IndexRange xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"></IndexRange>
+                                    <SubstituteValue xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                                        <Value>
+                                            <String>Array Element Three Substitute</String>
+                                        </Value>
+                                    </SubstituteValue>
+                                    <MetaDataProperties xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd"/>
+                                </PublishedData>
+                                <Bool>false</Bool>
+                                <SByte>0</SByte>
+                                <Int16>0</Int16>
+                                <UInt16>0</UInt16>
+                                <Int32>0</Int32>
+                                <UInt32>0</UInt32>
+                                <Int64>0</Int64>
+                                <UInt64>0</UInt64>
+                                <Float>0</Float>
+                                <Double>987.6543</Double>
+                                <String></String>
+                                <DateTime>1900-01-01T00:00:00Z</DateTime>
+                                <Guid>
+                                    <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">00000000-0000-0000-0000-000000000000</String>
+                                </Guid>
+                                <ByteString></ByteString>
+                                <NodeId>
+                                    <Identifier xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">i=0</Identifier>
+                                </NodeId>
+                                <StatusCode>
+                                    <Code xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</Code>
+                                </StatusCode>
+                                <QualifiedName>
+                                    <NamespaceIndex xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">0</NamespaceIndex>
+                                    <Name xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Name>
+                                </QualifiedName>
+                                <LocalizedText>
+                                    <Text xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">Array Element Three</Text>
+                                </LocalizedText>
+                            </ComprehensiveScalarType>
+
+
+
+                        </ScalarAsArray>
+                    </ComplexComprehensiveType>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+
+
+
     <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5001" BrowseName="Default Binary">
         <DisplayName>Default Binary</DisplayName>
         <References>

--- a/SystemTest/NodeSetFiles/LevelOne.xml
+++ b/SystemTest/NodeSetFiles/LevelOne.xml
@@ -57,7 +57,7 @@
         <Definition Name="1:ComprehensiveScalarType">
             <Field DataType="DataSetMetaDataType" Name="DataSet"/>
             <Field DataType="PublishedVariableDataType" Name="PublishedData"/>
-            <Field DataType="Double" Name="Bool"/>
+            <Field DataType="Boolean" Name="Bool"/>
             <Field DataType="SByte" Name="SByte"/>
             <Field DataType="Int16" Name="Int16"/>
             <Field DataType="UInt16" Name="UInt16"/>

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="3.1.2" />
-    <PackageReference Include="Aml.Engine.Resources" Version="2.0.3" />
-    <PackageReference Include="Aml.Engine.Services" Version="3.0.6" />
+    <PackageReference Include="Aml.Engine" Version="3.2.1" />
+    <PackageReference Include="Aml.Engine.Resources" Version="3.0.0" />
+    <PackageReference Include="Aml.Engine.Services" Version="3.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />

--- a/SystemTest/TestAttributes.cs
+++ b/SystemTest/TestAttributes.cs
@@ -12,45 +12,6 @@ namespace SystemTest
     public class TestAttributes
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
-
 
         #region Tests
 
@@ -125,7 +86,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -85,17 +85,51 @@ namespace SystemTest
             TestValue( innerDiagnosticAttribute, "AdditionalInfo", "Even More Diagnostic Information", "xs:string" );
             TestValue( innerDiagnosticAttribute, "InnerStatusCode", "2165637122", "xs:unsignedInt" );
 
+            #endregion
 
+            #region DataSet Extension
 
-            return;
+            AttributeType dataSetAttribute = GetAttribute( value, "DataSet", validateSubAttributes: true );
 
-            //ValidateNodeId( structureDataType, "DataTypeId", InstanceLevel, new NodeId( 99 ) );
+            #region Simple
+
+            TestValue( dataSetAttribute, "Name", "Data Set Name", "xs:string" );
+            ValidateLocalizedText( dataSetAttribute, "Description", "Data Set Description" );
+            TestValue( dataSetAttribute, "DataSetClassId", "98769876-9876-9876-9876-987698769876", "xs:string" );
+            AttributeType configurationVersionAttribute = GetAttribute( dataSetAttribute, "ConfigurationVersion", validateSubAttributes: true );
+            TestValue( configurationVersionAttribute, "MajorVersion", "54", "xs:unsignedInt" );
+            TestValue( configurationVersionAttribute, "MinorVersion", "32", "xs:unsignedInt" );
+
+            #region Namespaces Variable
+
+            AttributeType namespaces = GetAttribute( dataSetAttribute, "Namespaces", validateSubAttributes: true );
+            Assert.AreEqual( 3, namespaces.Attribute.Count, "Invalid namespace count" );
+            TestValue( namespaces, "1", LevelTwo, "xs:string" );
+
+            #endregion
+
+            #endregion
+
+            #region Complex
+
+            #region StructureDataTypes
+
+            AttributeType structureDataTypes = GetAttribute( dataSetAttribute, "StructureDataTypes", validateSubAttributes: true );
+            Assert.AreEqual( 3, structureDataTypes.Attribute.Count, "Invalid Structure count" );
+            AttributeType structureDescriptionType = GetAttribute( structureDataTypes, "1", validateSubAttributes: true );
+
+            ValidateNodeId( structureDescriptionType, "DataTypeId", GetUri( 2 ), new NodeId( 2223 ) );
+            ValidateQualifiedName( structureDescriptionType, "Name", GetUri( 2 ), "Structure Description Two" );
+
+            AttributeType structureDefinitionType = GetAttribute( structureDescriptionType, "StructureDefinition", validateSubAttributes: true );
+            ValidateNodeId( structureDefinitionType, "DefaultEncodingId", RootLevel, new NodeId( 8 ) );
+            ValidateNodeId( structureDefinitionType, "BaseDataType", RootLevel, new NodeId( 9 ) );
+            TestValue( structureDefinitionType, "StructureType", "UnionWithSubtypedValues", "xs:string" );
 
 
             #endregion
 
-
-            #region DataSet Extension
+            #endregion
 
             #endregion
 
@@ -103,80 +137,74 @@ namespace SystemTest
 
             #endregion
 
-            #region Namespaces Variable
+            //#region Namespaces Variable
 
-            AttributeType namespaces = GetAttribute( value, "Namespaces", validateSubAttributes: true );
-            Assert.AreEqual( 3, namespaces.Attribute.Count, "Invalid namespace count" );
-            AttributeType namespaceAttribute = GetAttribute( namespaces, "0", validateSubAttributes: false );
-            Assert.AreEqual( LevelOne, namespaceAttribute.Value );
-            Assert.AreEqual( "xs:string", namespaceAttribute.AttributeDataType );
-            namespaceAttribute = GetAttribute( namespaces, "1", validateSubAttributes: false );
-            Assert.AreEqual( LevelTwo, namespaceAttribute.Value );
-            Assert.AreEqual( "xs:string", namespaceAttribute.AttributeDataType );
-            namespaceAttribute = GetAttribute( namespaces, "2", validateSubAttributes: false );
-            Assert.AreEqual( InstanceLevel, namespaceAttribute.Value );
-            Assert.AreEqual( "xs:string", namespaceAttribute.AttributeDataType );
+            //AttributeType namespaces = GetAttribute( value, "Namespaces", validateSubAttributes: true );
+            //Assert.AreEqual( 3, namespaces.Attribute.Count, "Invalid namespace count" );
+            //AttributeType namespaceAttribute = GetAttribute( namespaces, "1", validateSubAttributes: false );
+            //Assert.AreEqual( LevelTwo, namespaceAttribute.Value );
+            //Assert.AreEqual( "xs:string", namespaceAttribute.AttributeDataType );
 
-            #endregion
+            //#endregion
 
-            #region Structure Data Type
+            //#region Structure Data Type
 
-            AttributeType structureDataTypes = GetAttribute( value, "StructureDataTypes", validateSubAttributes: true );
-            Assert.AreEqual( 1, structureDataTypes.Attribute.Count, "Invalid namespace count" );
-            AttributeType structureDataType = GetAttribute( structureDataTypes, "0", validateSubAttributes: true );
+            //AttributeType structureDataTypes = GetAttribute( value, "StructureDataTypes", validateSubAttributes: true );
+            //Assert.AreEqual( 1, structureDataTypes.Attribute.Count, "Invalid namespace count" );
+            //AttributeType structureDataType = GetAttribute( structureDataTypes, "0", validateSubAttributes: true );
 
-            ValidateNodeId( structureDataType, "DataTypeId", InstanceLevel, new NodeId( 99 ) );
-            ValidateQualifiedName( structureDataType, "Name", RootLevel, "Structure Description One" );
+            //ValidateNodeId( structureDataType, "DataTypeId", InstanceLevel, new NodeId( 99 ) );
+            //ValidateQualifiedName( structureDataType, "Name", RootLevel, "Structure Description One" );
 
-            AttributeType structureDefinition = GetAttribute( structureDataType, "StructureDefinition", validateSubAttributes: true );
-            ValidateNodeId( structureDefinition, "DefaultEncodingId", LevelOne, new NodeId( "EncodingOne" ) );
-            ValidateNodeId( structureDefinition, "BaseDataType", LevelOne, new NodeId( "BaseDataTypeOne" ) );
+            //AttributeType structureDefinition = GetAttribute( structureDataType, "StructureDefinition", validateSubAttributes: true );
+            //ValidateNodeId( structureDefinition, "DefaultEncodingId", LevelOne, new NodeId( "EncodingOne" ) );
+            //ValidateNodeId( structureDefinition, "BaseDataType", LevelOne, new NodeId( "BaseDataTypeOne" ) );
 
-            AttributeType structureType = GetAttribute( structureDefinition, "StructureType", validateSubAttributes: false );
-            Assert.AreEqual( "Structure", structureType.Value );
-            Assert.AreEqual( "xs:string", structureType.AttributeDataType );
+            //AttributeType structureType = GetAttribute( structureDefinition, "StructureType", validateSubAttributes: false );
+            //Assert.AreEqual( "Structure", structureType.Value );
+            //Assert.AreEqual( "xs:string", structureType.AttributeDataType );
 
-            AttributeType structureFields = GetAttribute( structureDefinition, "Fields", validateSubAttributes: true );
-            Assert.AreEqual( 2, structureFields.Attribute.Count, "Invalid namespace count" );
+            //AttributeType structureFields = GetAttribute( structureDefinition, "Fields", validateSubAttributes: true );
+            //Assert.AreEqual( 2, structureFields.Attribute.Count, "Invalid namespace count" );
 
-            AttributeType testOneStructureField = GetAttribute( structureFields, "1", validateSubAttributes: true );
-            AttributeType structureFieldName = GetAttribute( testOneStructureField, "Name", validateSubAttributes: false );
-            Assert.AreEqual( "StructureFieldTwo", structureFieldName.Value );
+            //AttributeType testOneStructureField = GetAttribute( structureFields, "1", validateSubAttributes: true );
+            //AttributeType structureFieldName = GetAttribute( testOneStructureField, "Name", validateSubAttributes: false );
+            //Assert.AreEqual( "StructureFieldTwo", structureFieldName.Value );
 
-            AttributeType structureFieldDescription = GetAttribute( testOneStructureField, "Description", validateSubAttributes: false );
-            Assert.AreEqual( "Structure Field Two Description", structureFieldDescription.Value );
+            //AttributeType structureFieldDescription = GetAttribute( testOneStructureField, "Description", validateSubAttributes: false );
+            //Assert.AreEqual( "Structure Field Two Description", structureFieldDescription.Value );
 
-            ValidateNodeId( testOneStructureField, "DataType", RootLevel, Opc.Ua.DataTypeIds.String );
+            //ValidateNodeId( testOneStructureField, "DataType", RootLevel, Opc.Ua.DataTypeIds.String );
 
-            #endregion
+            //#endregion
 
-            #region Fields
+            //#region Fields
 
-            AttributeType fields = GetAttribute( value, "Fields", validateSubAttributes: true );
-            Assert.AreEqual( 4, fields.Attribute.Count, "Invalid Fields count" );
+            //AttributeType fields = GetAttribute( value, "Fields", validateSubAttributes: true );
+            //Assert.AreEqual( 4, fields.Attribute.Count, "Invalid Fields count" );
 
-            AttributeType field = GetAttribute( fields, "2", validateSubAttributes: true );
+            //AttributeType field = GetAttribute( fields, "2", validateSubAttributes: true );
 
-            AttributeType fieldName = GetAttribute( field, "Name", validateSubAttributes: false );
-            Assert.AreEqual( "FloatArray", fieldName.Value );
+            //AttributeType fieldName = GetAttribute( field, "Name", validateSubAttributes: false );
+            //Assert.AreEqual( "FloatArray", fieldName.Value );
 
-            AttributeType fieldDescription = GetAttribute( field, "Description", validateSubAttributes: false );
-            Assert.AreEqual( "FieldMetaData Description for FloatArray", fieldDescription.Value );
+            //AttributeType fieldDescription = GetAttribute( field, "Description", validateSubAttributes: false );
+            //Assert.AreEqual( "FieldMetaData Description for FloatArray", fieldDescription.Value );
 
-            ValidateNodeId( field, "DataType", RootLevel, Opc.Ua.DataTypeIds.Float );
+            //ValidateNodeId( field, "DataType", RootLevel, Opc.Ua.DataTypeIds.Float );
 
-            AttributeType valueRank = GetAttribute( field, "ValueRank", validateSubAttributes: false );
-            Assert.AreEqual( "1", valueRank.Value );
+            //AttributeType valueRank = GetAttribute( field, "ValueRank", validateSubAttributes: false );
+            //Assert.AreEqual( "1", valueRank.Value );
 
-            AttributeType arrayDimensions = GetAttribute( field, "ArrayDimensions", validateSubAttributes: true );
-            AttributeType arrayDimension = GetAttribute( arrayDimensions, "0", validateSubAttributes: false );
-            Assert.AreEqual( "5", arrayDimension.Value );
+            //AttributeType arrayDimensions = GetAttribute( field, "ArrayDimensions", validateSubAttributes: true );
+            //AttributeType arrayDimension = GetAttribute( arrayDimensions, "0", validateSubAttributes: false );
+            //Assert.AreEqual( "5", arrayDimension.Value );
 
-            AttributeType builtIntype = GetAttribute( field, "BuiltInType", validateSubAttributes: false );
-            Assert.AreEqual( "Float", builtIntype.Value );
-            Assert.AreEqual( "xs:string", builtIntype.AttributeDataType );
+            //AttributeType builtIntype = GetAttribute( field, "BuiltInType", validateSubAttributes: false );
+            //Assert.AreEqual( "Float", builtIntype.Value );
+            //Assert.AreEqual( "xs:string", builtIntype.AttributeDataType );
 
-            #endregion
+            //#endregion
         }
 
         public void TestValue( AttributeType source, string target, string value, string type )
@@ -346,6 +374,32 @@ namespace SystemTest
             }
 
             return attribute;
+        }
+
+        public string GetUri( int namespaceIndex )
+        {
+            string uri = "";
+
+            switch(  namespaceIndex )
+            {
+                case 0:
+                    uri = RootLevel;
+                    break;
+
+                case 1:
+                    uri = InstanceLevel;
+                    break;
+
+                case 2:
+                    uri = LevelOne;
+                    break;
+
+                case 3:
+                    uri = LevelTwo;
+                    break;
+            }
+
+            return uri;
         }
 
         public void ValidateNodeId( AttributeType attribute, string name, string uri, NodeId nodeId )

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -109,6 +109,190 @@ namespace SystemTest
 
             #region Complex
 
+            TestDataSetComplex( value );
+
+            //#region StructureDataTypes
+
+            //AttributeType structureDataTypes = GetAttribute( dataSetAttribute, "StructureDataTypes", validateSubAttributes: true );
+            //Assert.AreEqual( 3, structureDataTypes.Attribute.Count, "Invalid Structure count" );
+            //AttributeType structureDescriptionType = GetAttribute( structureDataTypes, "1", validateSubAttributes: true );
+
+            //ValidateNodeId( structureDescriptionType, "DataTypeId", GetUri( 2 ), new NodeId( 2223 ) );
+            //ValidateQualifiedName( structureDescriptionType, "Name", GetUri( 2 ), "Structure Description Two" );
+
+            //AttributeType structureDefinitionType = GetAttribute( structureDescriptionType, "StructureDefinition", validateSubAttributes: true );
+            //ValidateNodeId( structureDefinitionType, "DefaultEncodingId", RootLevel, new NodeId( 8 ) );
+            //ValidateNodeId( structureDefinitionType, "BaseDataType", RootLevel, new NodeId( 9 ) );
+            //TestValue( structureDefinitionType, "StructureType", "UnionWithSubtypedValues", "xs:string" );
+
+            //#endregion
+
+            //#region EnumDataTypes
+
+            //AttributeType enumDataTypes = GetAttribute( dataSetAttribute, "EnumDataTypes", validateSubAttributes: true );
+            //Assert.AreEqual( 3, enumDataTypes.Attribute.Count, "Invalid Enum Structure count" );
+            //AttributeType enumDataType = GetAttribute( enumDataTypes, "1", validateSubAttributes: true );
+
+            //ValidateNodeId( enumDataType, "DataTypeId", GetUri( 3 ), new NodeId( 2346 ) );
+            //ValidateQualifiedName( enumDataType, "Name", GetUri( 3 ), "Another Enum Description" );
+            //TestValue( enumDataType, "BuiltInType", "Int16", "xs:string" );
+
+            //AttributeType enumDefinitions = GetAttribute( enumDataType, "EnumDefinition", validateSubAttributes: true );
+            //AttributeType enumFields = GetAttribute( enumDefinitions, "Fields", validateSubAttributes: true );
+            //Assert.AreEqual( 3, enumFields.Attribute.Count, "Invalid Enum Fields count" );
+
+            //AttributeType enumField = GetAttribute( enumFields, "1", validateSubAttributes: true );
+            //TestValue( enumField, "Value", "56", "xs:long" );
+            //TestValue( enumField, "Name", "Fifty Six", "xs:string" );
+            //ValidateLocalizedText( enumField, "DisplayName", "Fifty Six" );
+            //ValidateLocalizedText( enumField, "Description", "Fifty Six" );
+
+            //#endregion
+
+            //#region SimpleDataTypes
+
+            //AttributeType simpleDataTypes = GetAttribute( dataSetAttribute, "SimpleDataTypes", validateSubAttributes: true );
+            //Assert.AreEqual( 3, simpleDataTypes.Attribute.Count, "Invalid Simple Data Type count" );
+            //AttributeType simpleDataType = GetAttribute( simpleDataTypes, "1", validateSubAttributes: true );
+
+            //ValidateNodeId( simpleDataType, "DataTypeId", GetUri( 3 ), new NodeId( 891 ) );
+            //ValidateQualifiedName( simpleDataType, "Name", GetUri( 1 ), "EvenMoreSimple" );
+            //ValidateNodeId( simpleDataType, "BaseDataType", GetUri( 0 ), new NodeId( 8 ) );
+            //TestValue( simpleDataType, "BuiltInType", "Int64", "xs:string" );
+
+            //#endregion
+
+            //#region Fields
+
+            //AttributeType fields = GetAttribute( dataSetAttribute, "Fields", validateSubAttributes: true );
+            //Assert.AreEqual( 3, fields.Attribute.Count, "Invalid Field count" );
+            //AttributeType field = GetAttribute( fields, "1", validateSubAttributes: true );
+
+            //TestValue( field, "Name", "Field Two", "xs:string" );
+            //ValidateLocalizedText( field, "Description", "Field Two" );
+            //// Unsure on what type this should actually be.  Boolean does not make sense, as there could be multiple fields
+            //// This doesn't work at all.  FieldFlags is UInt16
+            ////TestValue( field, "FieldFlags", "1", "xs:unsignedShort" );
+            //TestValue( field, "BuiltInType", "Float", "xs:string" );
+            //ValidateNodeId( field, "DataType", GetUri( 0 ), new NodeId( 10 ) );
+            //TestValue( field, "ValueRank", "1", "xs:int" );
+            //ValidateArrayDimensions( field, new string[] { "3" } );
+            //TestValue( field, "MaxStringLength", "333", "xs:unsignedInt" );
+            //TestValue( field, "DataSetFieldId", "12341234-1234-1234-1234-123412341234", "xs:string" );
+
+            //AttributeType properties = GetAttribute( field, "Properties", validateSubAttributes: true );
+            //Assert.AreEqual( 2, properties.Attribute.Count, "Invalid Properties count" );
+            //AttributeType stringProperty = GetAttribute( properties, "0", validateSubAttributes: true );
+            //ValidateQualifiedName( stringProperty, "Key", GetUri( 0 ), "PropertyOne" );
+            //TestValue( stringProperty, "Value", "PropertyOne", "xs:string" );
+
+            //AttributeType intProperty = GetAttribute( properties, "1", validateSubAttributes: true );
+            //ValidateQualifiedName( intProperty, "Key", GetUri( 2 ), "PropertyTwo" );
+            //TestValue( intProperty, "Value", "2", "xs:int" );
+
+            //#endregion
+
+            #endregion
+
+            #endregion
+
+            #region PublishedData Extension
+
+            AttributeType publishedDataAttribute = GetAttribute( value, "PublishedData", validateSubAttributes: true );
+
+            ValidateNodeId( publishedDataAttribute, "PublishedVariable", GetUri(1 ), new NodeId( 987 ) );
+            TestValue( publishedDataAttribute, "AttributeId", "13", "xs:unsignedInt" );
+            TestValue( publishedDataAttribute, "SamplingIntervalHint", "666", "xs:double" );
+            TestValue( publishedDataAttribute, "DeadbandType", "5", "xs:unsignedInt" );
+            TestValue( publishedDataAttribute, "DeadbandValue", "4", "xs:double" );
+            TestValue( publishedDataAttribute, "IndexRange", "4:5", "xs:string" );
+            TestValue( publishedDataAttribute, "SubstituteValue", "123456789", "xs:unsignedLong" );
+
+            AttributeType metaDataAttributes = GetAttribute( publishedDataAttribute, "MetaDataProperties", validateSubAttributes: true );
+
+            Assert.AreEqual( 3, metaDataAttributes.Attribute.Count, "Invalid Structure count" );
+            ValidateQualifiedName( metaDataAttributes, "1", GetUri( 3 ), "Two" );
+
+            #endregion
+        }
+
+        [TestMethod]
+        public void TestLevelTwo()
+        {
+            AttributeType value = InitialGetValueAttribute( "LevelTwo" );
+
+            TestComprehensiveArray( value );
+
+            return;
+        }
+
+        [TestMethod]
+        public void TestTopLevel()
+        {
+            AttributeType topLevel = InitialGetValueAttribute( "TopLevel" );
+            AttributeType arrayAsScalar = GetAttribute( topLevel, "ArrayAsScalar", validateSubAttributes : true );
+
+            TestComprehensiveArray( arrayAsScalar );
+
+            AttributeType scalarAsArray = GetMiddleArrayElement( topLevel, "ScalarAsArray" );
+
+            TestComprehensiveScalar( scalarAsArray );
+        }
+
+        private void TestComprehensiveArray( AttributeType value )
+        {
+            #region ComprehensiveScalarType
+
+            AttributeType complexType = GetMiddleArrayElement( value, "LevelOne" );
+
+            TestComprehensiveScalar( complexType );
+
+            #endregion
+
+            #region Other Array Values
+
+            TestValueMidArray( value, "Int16", "1", "xs:short" );
+            TestValueMidArray( value, "UInt16", "5", "xs:unsignedShort" );
+            TestValueMidArray( value, "DateTime", "2008-01-01T00:00:00-07:00", "xs:dateTime" );
+            TestValueMidArray( value, "Guid", "11001100-1100-1100-1100-110011001100", "xs:string" );
+            TestValueMidArray( value, "ByteString", "MTQ=", "xs:base64Binary" );
+
+            AttributeType nodeIds = GetAttribute( value, "NodeId", validateSubAttributes: true );
+            ValidateNodeId( nodeIds, "1", GetUri( 2 ), new NodeId( 2 ) );
+
+            AttributeType qualifiedNames = GetAttribute( value, "QualifiedName", validateSubAttributes: true );
+            ValidateQualifiedName( qualifiedNames, "1", GetUri( 2 ), "Two" );
+            AttributeType localizedTexts = GetAttribute( value, "LocalizedText", validateSubAttributes: true );
+            ValidateLocalizedText( localizedTexts, "1", "Two" );
+
+            #endregion
+
+        }
+
+        private void TestComprehensiveScalar( AttributeType value )
+        {
+            ValidateQualifiedName( value, "QualifiedName", GetUri( 0 ), "Array Element Two" );
+            ValidateLocalizedText( value, "LocalizedText", "Array Element Two" );
+
+            AttributeType dataSetType = GetAttribute( value, "DataSet", validateSubAttributes: true );
+
+            AttributeType namespacesType = GetAttribute( dataSetType, "Namespaces", validateSubAttributes: true );
+            TestValue( namespacesType, "1", "http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/", "xs:string" );
+            TestValue( dataSetType, "DataSetClassId", "24682468-2468-2468-2468-246824682468", "xs:string" );
+            AttributeType configurationVersionType = GetAttribute( dataSetType, "ConfigurationVersion", validateSubAttributes: true );
+            TestValue( configurationVersionType, "MajorVersion", "3", "xs:unsignedInt" );
+            TestValue( configurationVersionType, "MinorVersion", "4", "xs:unsignedInt" );
+
+            AttributeType publishedDataType = GetAttribute( value, "PublishedData", validateSubAttributes: true );
+            TestValue( publishedDataType, "SubstituteValue", "Array Element Two Substitute", "xs:string" );
+
+            TestDataSetComplex( value );
+        }
+
+        private void TestDataSetComplex( AttributeType value )
+        {
+            AttributeType dataSetAttribute = GetAttribute( value, "DataSet", validateSubAttributes: true );
+
             #region StructureDataTypes
 
             AttributeType structureDataTypes = GetAttribute( dataSetAttribute, "StructureDataTypes", validateSubAttributes: true );
@@ -189,79 +373,6 @@ namespace SystemTest
             TestValue( intProperty, "Value", "2", "xs:int" );
 
             #endregion
-
-            #endregion
-
-            #endregion
-
-            #region PublishedData Extension
-
-            AttributeType publishedDataAttribute = GetAttribute( value, "PublishedData", validateSubAttributes: true );
-
-            ValidateNodeId( publishedDataAttribute, "PublishedVariable", GetUri(1 ), new NodeId( 987 ) );
-            TestValue( publishedDataAttribute, "AttributeId", "13", "xs:unsignedInt" );
-            TestValue( publishedDataAttribute, "SamplingIntervalHint", "666", "xs:double" );
-            TestValue( publishedDataAttribute, "DeadbandType", "5", "xs:unsignedInt" );
-            TestValue( publishedDataAttribute, "DeadbandValue", "4", "xs:double" );
-            TestValue( publishedDataAttribute, "IndexRange", "4:5", "xs:string" );
-            TestValue( publishedDataAttribute, "SubstituteValue", "123456789", "xs:unsignedLong" );
-
-            AttributeType metaDataAttributes = GetAttribute( publishedDataAttribute, "MetaDataProperties", validateSubAttributes: true );
-
-            Assert.AreEqual( 3, metaDataAttributes.Attribute.Count, "Invalid Structure count" );
-            ValidateQualifiedName( metaDataAttributes, "1", GetUri( 3 ), "Two" );
-
-            #endregion
-        }
-
-        [TestMethod]
-        public void TestLevelTwo()
-        {
-            AttributeType value = InitialGetValueAttribute( "LevelTwo" );
-
-            #region ComprehensiveScalarType
-
-            AttributeType complexType = GetMiddleArrayElement( value, "LevelOne" );
-
-            ValidateQualifiedName( complexType, "QualifiedName", GetUri( 0 ), "Array Element Two" );
-            ValidateLocalizedText( complexType, "LocalizedText", "Array Element Two" );
-
-            AttributeType dataSetType = GetAttribute( complexType, "DataSet", validateSubAttributes: true );
-
-            AttributeType namespacesType = GetAttribute( dataSetType, "Namespaces", validateSubAttributes: true );
-            TestValue( namespacesType, "1", "http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/", "xs:string" );
-            TestValue( dataSetType, "DataSetClassId", "24682468-2468-2468-2468-246824682468", "xs:string" );
-            AttributeType configurationVersionType = GetAttribute( dataSetType, "ConfigurationVersion", validateSubAttributes: true );
-            TestValue( configurationVersionType, "MajorVersion", "3", "xs:unsignedInt" );
-            TestValue( configurationVersionType, "MinorVersion", "4", "xs:unsignedInt" );
-
-            AttributeType publishedDataType = GetAttribute( complexType, "PublishedData", validateSubAttributes: true );
-            TestValue( publishedDataType, "SubstituteValue", "Array Element Two Substitute", "xs:string" );
-
-            #endregion
-
-            #region Other Array Values
-
-            TestValueMidArray( value, "Int16", "1", "xs:short" );
-            TestValueMidArray( value, "UInt16", "5", "xs:unsignedShort" );
-            TestValueMidArray( value, "DateTime", "2008-01-01T00:00:00-07:00", "xs:dateTime" );
-            TestValueMidArray( value, "Guid", "11001100-1100-1100-1100-110011001100", "xs:string" );
-            TestValueMidArray( value, "ByteString", "MTQ=", "xs:base64Binary" );
-
-            AttributeType nodeIds = GetAttribute( value, "NodeId", validateSubAttributes: true );
-            ValidateNodeId( nodeIds, "1", GetUri( 2 ), new NodeId( 2 ) );
-
-            AttributeType qualifiedNames = GetAttribute( value, "QualifiedName", validateSubAttributes: true );
-            ValidateQualifiedName( qualifiedNames, "1", GetUri( 2 ), "Two" );
-            AttributeType localizedTexts = GetAttribute( value, "LocalizedText", validateSubAttributes: true );
-            ValidateLocalizedText( localizedTexts, "1", "Two" );
-
-            #endregion
-        }
-
-        [TestMethod]
-        public void TestTopLevel()
-        {
 
         }
 
@@ -378,6 +489,8 @@ namespace SystemTest
             AttributeType metaDataProperty = GetAttribute( metaDataProperties, "1", validateSubAttributes: true );
             ValidateQualifiedName( metaDataProperties, "1", RootLevel, "anothername" );
         }
+
+
 
 
         #endregion

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System.Collections.Generic;
 using Aml.Engine.AmlObjects;
 using Aml.Engine.CAEX;
 using Aml.Engine.CAEX.Extensions;
@@ -7,6 +8,8 @@ using Opc.Ua;
 using System.Reflection.Metadata;
 using Opc.Ua.Gds;
 using System;
+using System.Xml.Linq;
+using System.Linq;
 
 namespace SystemTest
 {
@@ -126,6 +129,70 @@ namespace SystemTest
             ValidateNodeId( structureDefinitionType, "BaseDataType", RootLevel, new NodeId( 9 ) );
             TestValue( structureDefinitionType, "StructureType", "UnionWithSubtypedValues", "xs:string" );
 
+            #endregion
+
+            #region EnumDataTypes
+
+            AttributeType enumDataTypes = GetAttribute( dataSetAttribute, "EnumDataTypes", validateSubAttributes: true );
+            Assert.AreEqual( 3, enumDataTypes.Attribute.Count, "Invalid Enum Structure count" );
+            AttributeType enumDataType = GetAttribute( enumDataTypes, "1", validateSubAttributes: true );
+
+            ValidateNodeId( enumDataType, "DataTypeId", GetUri( 3 ), new NodeId( 2346 ) );
+            ValidateQualifiedName( enumDataType, "Name", GetUri( 3 ), "Another Enum Description" );
+            TestValue( enumDataType, "BuiltInType", "Int16", "xs:string" );
+
+            AttributeType enumDefinitions = GetAttribute( enumDataType, "EnumDefinition", validateSubAttributes: true );
+            AttributeType enumFields = GetAttribute( enumDefinitions, "Fields", validateSubAttributes: true );
+            Assert.AreEqual( 3, enumFields.Attribute.Count, "Invalid Enum Fields count" );
+
+            AttributeType enumField = GetAttribute( enumFields, "1", validateSubAttributes: true );
+            TestValue( enumField, "Value", "56", "xs:long" );
+            TestValue( enumField, "Name", "Fifty Six", "xs:string" );
+            ValidateLocalizedText( enumField, "DisplayName", "Fifty Six" );
+            ValidateLocalizedText( enumField, "Description", "Fifty Six" );
+
+            #endregion
+
+            #region SimpleDataTypes
+
+            AttributeType simpleDataTypes = GetAttribute( dataSetAttribute, "SimpleDataTypes", validateSubAttributes: true );
+            Assert.AreEqual( 3, simpleDataTypes.Attribute.Count, "Invalid Simple Data Type count" );
+            AttributeType simpleDataType = GetAttribute( simpleDataTypes, "1", validateSubAttributes: true );
+
+            ValidateNodeId( simpleDataType, "DataTypeId", GetUri( 3 ), new NodeId( 891 ) );
+            ValidateQualifiedName( simpleDataType, "Name", GetUri( 1 ), "EvenMoreSimple" );
+            ValidateNodeId( simpleDataType, "BaseDataType", GetUri( 0 ), new NodeId( 8 ) );
+            TestValue( simpleDataType, "BuiltInType", "Int64", "xs:string" );
+
+            #endregion
+
+            #region Fields
+
+            AttributeType fields = GetAttribute( dataSetAttribute, "Fields", validateSubAttributes: true );
+            Assert.AreEqual( 3, fields.Attribute.Count, "Invalid Field count" );
+            AttributeType field = GetAttribute( fields, "1", validateSubAttributes: true );
+
+            TestValue( field, "Name", "Field Two", "xs:string" );
+            ValidateLocalizedText( field, "Description", "Field Two" );
+            // Unsure on what type this should actually be.  Boolean does not make sense, as there could be multiple fields
+            // This doesn't work at all.  FieldFlags is UInt16
+            //TestValue( field, "FieldFlags", "1", "xs:unsignedShort" );
+            TestValue( field, "BuiltInType", "Float", "xs:string" );
+            ValidateNodeId( field, "DataType", GetUri( 0 ), new NodeId( 10 ) );
+            TestValue( field, "ValueRank", "1", "xs:int" );
+            ValidateArrayDimensions( field, new string[] { "3" } );
+            TestValue( field, "MaxStringLength", "333", "xs:unsignedInt" );
+            TestValue( field, "DataSetFieldId", "12341234-1234-1234-1234-123412341234", "xs:string" );
+
+            AttributeType properties = GetAttribute( field, "Properties", validateSubAttributes: true );
+            Assert.AreEqual( 2, properties.Attribute.Count, "Invalid Properties count" );
+            AttributeType stringProperty = GetAttribute( properties, "0", validateSubAttributes: true );
+            ValidateQualifiedName( stringProperty, "Key", GetUri( 0 ), "PropertyOne" );
+            TestValue( stringProperty, "Value", "PropertyOne", "xs:string" );
+
+            AttributeType intProperty = GetAttribute( properties, "1", validateSubAttributes: true );
+            ValidateQualifiedName( intProperty, "Key", GetUri( 2 ), "PropertyTwo" );
+            TestValue( intProperty, "Value", "2", "xs:int" );
 
             #endregion
 
@@ -135,76 +202,22 @@ namespace SystemTest
 
             #region PublishedData Extension
 
+            AttributeType publishedDataAttribute = GetAttribute( value, "PublishedData", validateSubAttributes: true );
+
+            ValidateNodeId( publishedDataAttribute, "PublishedVariable", GetUri(1 ), new NodeId( 987 ) );
+            TestValue( publishedDataAttribute, "AttributeId", "13", "xs:unsignedInt" );
+            TestValue( publishedDataAttribute, "SamplingIntervalHint", "666", "xs:double" );
+            TestValue( publishedDataAttribute, "DeadbandType", "5", "xs:unsignedInt" );
+            TestValue( publishedDataAttribute, "DeadbandValue", "4", "xs:double" );
+            TestValue( publishedDataAttribute, "IndexRange", "4:5", "xs:string" );
+            TestValue( publishedDataAttribute, "SubstituteValue", "123456789", "xs:unsignedLong" );
+
+            AttributeType metaDataAttributes = GetAttribute( publishedDataAttribute, "MetaDataProperties", validateSubAttributes: true );
+
+            Assert.AreEqual( 3, metaDataAttributes.Attribute.Count, "Invalid Structure count" );
+            ValidateQualifiedName( metaDataAttributes, "1", GetUri( 3 ), "Two" );
+
             #endregion
-
-            //#region Namespaces Variable
-
-            //AttributeType namespaces = GetAttribute( value, "Namespaces", validateSubAttributes: true );
-            //Assert.AreEqual( 3, namespaces.Attribute.Count, "Invalid namespace count" );
-            //AttributeType namespaceAttribute = GetAttribute( namespaces, "1", validateSubAttributes: false );
-            //Assert.AreEqual( LevelTwo, namespaceAttribute.Value );
-            //Assert.AreEqual( "xs:string", namespaceAttribute.AttributeDataType );
-
-            //#endregion
-
-            //#region Structure Data Type
-
-            //AttributeType structureDataTypes = GetAttribute( value, "StructureDataTypes", validateSubAttributes: true );
-            //Assert.AreEqual( 1, structureDataTypes.Attribute.Count, "Invalid namespace count" );
-            //AttributeType structureDataType = GetAttribute( structureDataTypes, "0", validateSubAttributes: true );
-
-            //ValidateNodeId( structureDataType, "DataTypeId", InstanceLevel, new NodeId( 99 ) );
-            //ValidateQualifiedName( structureDataType, "Name", RootLevel, "Structure Description One" );
-
-            //AttributeType structureDefinition = GetAttribute( structureDataType, "StructureDefinition", validateSubAttributes: true );
-            //ValidateNodeId( structureDefinition, "DefaultEncodingId", LevelOne, new NodeId( "EncodingOne" ) );
-            //ValidateNodeId( structureDefinition, "BaseDataType", LevelOne, new NodeId( "BaseDataTypeOne" ) );
-
-            //AttributeType structureType = GetAttribute( structureDefinition, "StructureType", validateSubAttributes: false );
-            //Assert.AreEqual( "Structure", structureType.Value );
-            //Assert.AreEqual( "xs:string", structureType.AttributeDataType );
-
-            //AttributeType structureFields = GetAttribute( structureDefinition, "Fields", validateSubAttributes: true );
-            //Assert.AreEqual( 2, structureFields.Attribute.Count, "Invalid namespace count" );
-
-            //AttributeType testOneStructureField = GetAttribute( structureFields, "1", validateSubAttributes: true );
-            //AttributeType structureFieldName = GetAttribute( testOneStructureField, "Name", validateSubAttributes: false );
-            //Assert.AreEqual( "StructureFieldTwo", structureFieldName.Value );
-
-            //AttributeType structureFieldDescription = GetAttribute( testOneStructureField, "Description", validateSubAttributes: false );
-            //Assert.AreEqual( "Structure Field Two Description", structureFieldDescription.Value );
-
-            //ValidateNodeId( testOneStructureField, "DataType", RootLevel, Opc.Ua.DataTypeIds.String );
-
-            //#endregion
-
-            //#region Fields
-
-            //AttributeType fields = GetAttribute( value, "Fields", validateSubAttributes: true );
-            //Assert.AreEqual( 4, fields.Attribute.Count, "Invalid Fields count" );
-
-            //AttributeType field = GetAttribute( fields, "2", validateSubAttributes: true );
-
-            //AttributeType fieldName = GetAttribute( field, "Name", validateSubAttributes: false );
-            //Assert.AreEqual( "FloatArray", fieldName.Value );
-
-            //AttributeType fieldDescription = GetAttribute( field, "Description", validateSubAttributes: false );
-            //Assert.AreEqual( "FieldMetaData Description for FloatArray", fieldDescription.Value );
-
-            //ValidateNodeId( field, "DataType", RootLevel, Opc.Ua.DataTypeIds.Float );
-
-            //AttributeType valueRank = GetAttribute( field, "ValueRank", validateSubAttributes: false );
-            //Assert.AreEqual( "1", valueRank.Value );
-
-            //AttributeType arrayDimensions = GetAttribute( field, "ArrayDimensions", validateSubAttributes: true );
-            //AttributeType arrayDimension = GetAttribute( arrayDimensions, "0", validateSubAttributes: false );
-            //Assert.AreEqual( "5", arrayDimension.Value );
-
-            //AttributeType builtIntype = GetAttribute( field, "BuiltInType", validateSubAttributes: false );
-            //Assert.AreEqual( "Float", builtIntype.Value );
-            //Assert.AreEqual( "xs:string", builtIntype.AttributeDataType );
-
-            //#endregion
         }
 
         public void TestValue( AttributeType source, string target, string value, string type )
@@ -468,6 +481,19 @@ namespace SystemTest
 
             Assert.AreEqual( expected, localizedTextAttribute.Value );
             Assert.AreEqual( "xs:string", localizedTextAttribute.AttributeDataType );
+        }
+
+        public void ValidateArrayDimensions( AttributeType attribute, string[] expected )
+        {
+            AttributeType arrayDimensions = GetAttribute( attribute, "ArrayDimensions", validateSubAttributes: false );
+            if ( expected.Length > 0 )
+            {
+                Assert.AreEqual( expected.Length, arrayDimensions.Attribute.Count );
+                for( int index = 0; index < expected.Length; index++ )
+                {
+                    TestValue( arrayDimensions, index.ToString(), expected[ index ], "xs:unsignedInt" );
+                }
+            }
         }
 
         #endregion

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -10,6 +10,7 @@ using Opc.Ua.Gds;
 using System;
 using System.Xml.Linq;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 
 namespace SystemTest
 {
@@ -211,6 +212,72 @@ namespace SystemTest
             ValidateQualifiedName( metaDataAttributes, "1", GetUri( 3 ), "Two" );
 
             #endregion
+        }
+
+        [TestMethod]
+        public void TestLevelTwo()
+        {
+            AttributeType value = InitialGetValueAttribute( "LevelTwo" );
+
+            #region ComprehensiveScalarType
+
+            AttributeType complexType = GetMiddleArrayElement( value, "LevelOne" );
+
+            ValidateQualifiedName( complexType, "QualifiedName", GetUri( 0 ), "Array Element Two" );
+            ValidateLocalizedText( complexType, "LocalizedText", "Array Element Two" );
+
+            AttributeType dataSetType = GetAttribute( complexType, "DataSet", validateSubAttributes: true );
+
+            AttributeType namespacesType = GetAttribute( dataSetType, "Namespaces", validateSubAttributes: true );
+            TestValue( namespacesType, "1", "http://opcfoundation.org/UA/FX/AML/TESTING/Unavailable/4/", "xs:string" );
+            TestValue( dataSetType, "DataSetClassId", "24682468-2468-2468-2468-246824682468", "xs:string" );
+            AttributeType configurationVersionType = GetAttribute( dataSetType, "ConfigurationVersion", validateSubAttributes: true );
+            TestValue( configurationVersionType, "MajorVersion", "3", "xs:unsignedInt" );
+            TestValue( configurationVersionType, "MinorVersion", "4", "xs:unsignedInt" );
+
+            AttributeType publishedDataType = GetAttribute( complexType, "PublishedData", validateSubAttributes: true );
+            TestValue( publishedDataType, "SubstituteValue", "Array Element Two Substitute", "xs:string" );
+
+            #endregion
+
+            #region Other Array Values
+
+            TestValueMidArray( value, "Int16", "1", "xs:short" );
+            TestValueMidArray( value, "UInt16", "5", "xs:unsignedShort" );
+            TestValueMidArray( value, "DateTime", "2008-01-01T00:00:00-07:00", "xs:dateTime" );
+            TestValueMidArray( value, "Guid", "11001100-1100-1100-1100-110011001100", "xs:string" );
+            TestValueMidArray( value, "ByteString", "MTQ=", "xs:base64Binary" );
+
+            AttributeType nodeIds = GetAttribute( value, "NodeId", validateSubAttributes: true );
+            ValidateNodeId( nodeIds, "1", GetUri( 2 ), new NodeId( 2 ) );
+
+            AttributeType qualifiedNames = GetAttribute( value, "QualifiedName", validateSubAttributes: true );
+            ValidateQualifiedName( qualifiedNames, "1", GetUri( 2 ), "Two" );
+            AttributeType localizedTexts = GetAttribute( value, "LocalizedText", validateSubAttributes: true );
+            ValidateLocalizedText( localizedTexts, "1", "Two" );
+
+            #endregion
+        }
+
+        [TestMethod]
+        public void TestTopLevel()
+        {
+
+        }
+
+        public AttributeType GetMiddleArrayElement( AttributeType attribute, string target )
+        {
+            AttributeType elements = GetAttribute( attribute, target, validateSubAttributes: true );
+            Assert.AreEqual( 3, elements.Attribute.Count );
+            return GetAttribute( elements, "1", validateSubAttributes: true );
+        }
+
+        public void TestValueMidArray( AttributeType source, string target, string value, string type )
+        {
+            AttributeType attribute = GetAttribute( source, target, validateSubAttributes: false );
+            Assert.IsNotNull( attribute );
+            Assert.AreEqual( 3, attribute.Attribute.Count );
+            TestValue( attribute, "1", value, type );
         }
 
         public void TestValue( AttributeType source, string target, string value, string type )

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -16,13 +16,6 @@ namespace SystemTest
     [TestClass]
     public class TestComplexNonRootNamespace
     {
-
-        #region Initialize
-
-
-        #endregion
-
-
         #region Tests
 
         private CAEXDocument m_document = null;

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -53,8 +53,8 @@ namespace SystemTest
                 "<TheFifteenthElement xmlns=\"http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd\">Fifteen</TheFifteenthElement>",
                 unknownDataType );
 
-            ValidateNodeId( value, "NodeId", LevelOne, new NodeId( 16 ) );
-            ValidateNodeId( value, "ExpandedNodeId", LevelOne, new NodeId( 17 ) );
+            ValidateNodeId( value, "NodeId", GetUri( 2 ), new NodeId( 16 ) );
+            ValidateNodeId( value, "ExpandedNodeId", GetUri( 2 ), new NodeId( 17 ) );
 
             TestValue( value, "StatusCode", "2149056512", "xs:unsignedInt" );
             ValidateQualifiedName( value, "QualifiedName", InstanceLevel, "Nineteen" );
@@ -101,7 +101,7 @@ namespace SystemTest
 
             AttributeType namespaces = GetAttribute( dataSetAttribute, "Namespaces", validateSubAttributes: true );
             Assert.AreEqual( 3, namespaces.Attribute.Count, "Invalid namespace count" );
-            TestValue( namespaces, "1", LevelTwo, "xs:string" );
+            TestValue( namespaces, "1", GetUri( 3 ), "xs:string" );
 
             #endregion
 
@@ -420,7 +420,7 @@ namespace SystemTest
             Assert.AreEqual( "3:5", receiveRange.Value);
             Assert.AreEqual( "xs:string", receiveRange.AttributeDataType );
 
-            ValidateNodeId( middleArrayValue, "TargetNodeId", LevelOne, new NodeId( 6080 ) );
+            ValidateNodeId( middleArrayValue, "TargetNodeId", GetUri( 2 ), new NodeId( 6080 ) );
 
             AttributeType attributeId = GetAttribute( middleArrayValue, "AttributeId", validateSubAttributes: false );
             Assert.AreEqual( "13", attributeId.Value );
@@ -455,7 +455,7 @@ namespace SystemTest
             Assert.AreEqual( 5, value.Attribute.Count, "Invalid PublishedVariableData Array count" );
 
             AttributeType middleArrayValue = GetAttribute( value, "2", validateSubAttributes: false );
-            ValidateNodeId( middleArrayValue, "PublishedVariable", LevelOne, new NodeId( 6077 ) );
+            ValidateNodeId( middleArrayValue, "PublishedVariable", GetUri( 2 ), new NodeId( 6077 ) );
 
             AttributeType attributeId = GetAttribute( middleArrayValue, "AttributeId", validateSubAttributes: false );
             Assert.AreEqual( "13", attributeId.Value );

--- a/SystemTest/TestComplexRootNamespace.cs
+++ b/SystemTest/TestComplexRootNamespace.cs
@@ -14,45 +14,6 @@ namespace SystemTest
     public class TestComplexRootNamespace
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("InstanceLevel.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
-
 
         #region Tests
 
@@ -247,7 +208,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "InstanceLevel.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/TestDataTypes.cs
+++ b/SystemTest/TestDataTypes.cs
@@ -18,45 +18,6 @@ namespace SystemTest
     public class TestDataTypes
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
-
 
         #region Tests
 
@@ -164,7 +125,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/TestEnums.cs
+++ b/SystemTest/TestEnums.cs
@@ -22,45 +22,6 @@ namespace SystemTest
     public class TestDisplay
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document= document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if ( m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
-
 
         #region Tests
 
@@ -206,7 +167,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/TestHelper.cs
+++ b/SystemTest/TestHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Aml.Engine.AmlObjects;
+using Aml.Engine.CAEX;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -17,6 +18,8 @@ namespace SystemTest
 
         static bool Executed = false;
 
+        static Dictionary<string, CAEXDocument> ReadOnlyDocuments = new Dictionary<string, CAEXDocument>();
+        
         public static List<FileInfo> RetrieveFiles()
         {
             if (!Executed)
@@ -37,6 +40,30 @@ namespace SystemTest
             List<FileInfo> amlxFiles = GetAmlxFiles();
             Assert.AreNotEqual(0, amlxFiles.Count, "Unable to get Converted Amlx files");
             return amlxFiles;
+        }
+
+        public static CAEXDocument GetReadOnlyDocument( string filename )
+        {
+            CAEXDocument document = null;
+
+            if ( !ReadOnlyDocuments.TryGetValue( filename, out document ) )
+            {
+                foreach( FileInfo fileInfo in RetrieveFiles() )
+                {
+                    if( fileInfo.Name.Equals( filename ) )
+                    {
+                        AutomationMLContainer container = new AutomationMLContainer( fileInfo.FullName,
+                            System.IO.FileMode.Open, FileAccess.Read );
+                        Assert.IsNotNull( container, "Unable to find container" );
+                        document = CAEXDocument.LoadFromStream( container.RootDocumentStream() );
+                        Assert.IsNotNull( document, "Unable to find document" );
+
+                        ReadOnlyDocuments.Add( filename, document );
+                    }
+                }
+            }
+
+            return document;
         }
 
         static public string GetRootName()

--- a/SystemTest/TestMultiDimensionalArray.cs
+++ b/SystemTest/TestMultiDimensionalArray.cs
@@ -12,45 +12,6 @@ namespace SystemTest
     public class TestMultiDimensionalArray
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
-
 
         #region Tests
 
@@ -125,7 +86,11 @@ namespace SystemTest
 
         private CAEXDocument GetDocument()
         {
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
             return m_document;
         }
 

--- a/SystemTest/TestNodeIds.cs
+++ b/SystemTest/TestNodeIds.cs
@@ -18,44 +18,6 @@ namespace SystemTest
     public class TestNodeIds
     {
         CAEXDocument m_document = null;
-        AutomationMLContainer m_container = null;
-
-        #region Initialize
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            if (m_document == null)
-            {
-                foreach (FileInfo fileInfo in TestHelper.RetrieveFiles())
-                {
-                    if (fileInfo.Name.Equals("TestAml.xml.amlx"))
-                    {
-                        m_container = new AutomationMLContainer(fileInfo.FullName,
-                            System.IO.FileMode.Open, FileAccess.Read);
-                        Assert.IsNotNull(m_container, "Unable to find container");
-                        CAEXDocument document = CAEXDocument.LoadFromStream(m_container.RootDocumentStream());
-                        Assert.IsNotNull(document, "Unable to find document");
-                        m_document = document;
-                    }
-                }
-            }
-
-            Assert.IsNotNull(m_document, "Unable to retrieve Document");
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (m_document != null)
-            {
-                m_document.Unload();
-            }
-            m_container.Dispose();
-
-        }
-
-        #endregion
 
 
         #region Tests
@@ -105,7 +67,7 @@ namespace SystemTest
 
         public InternalElementType? findInternalElementByName(string internelElemantName)
         {
-            foreach (var instanceHierarchy in m_document.CAEXFile.InstanceHierarchy)
+            foreach (var instanceHierarchy in GetDocument().CAEXFile.InstanceHierarchy)
             {
                 // browse all InternalElements deep and find element with name "FxRoot"
                 foreach (var internalElement in instanceHierarchy.Descendants<InternalElementType>())
@@ -117,6 +79,17 @@ namespace SystemTest
             return null;
 
         }
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
+
 
         #endregion
     }


### PR DESCRIPTION
Allow for the conversion of Complex Objects undefined by a binary representation

Use Case
FxVersion is defined in Opc.Ua.Fx.Ac.Nodeset2.xml.  The decoder cannot handle this, as there is no compiled definition for FxVersion, so it creates an extension object where the body is a System.XmlElement, and a more intelligent conversion is required.

A multi file test nodeset has been added to allow more complex testing.
System Test infrastructure has been upgraded to provide for more efficient test performance.
