### PR TITLE
Fix to address issues found in full nodeset file.

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -1325,29 +1325,32 @@ namespace MarkdownProcessor
             NodeId refDataType,
             Variant val )
         {
-            byte builtInTypeByte = (byte)val.Value;
-            string builtInTypeName = Enum.GetName( typeof( BuiltInType ), builtInTypeByte );
-
-            string path = BuildLibraryReference( ATLPrefix, MetaModelName, "BuiltInType" );
-            CAEXObject builtInTypeObject = m_cAEXDocument.FindByPath( path );
-            AttributeFamilyType attributeDefinition = builtInTypeObject as AttributeFamilyType;
-
             AttributeType createAttribute = null;
 
-            if ( attributeDefinition != null )
+            if( val.TypeInfo.BuiltInType.Equals( BuiltInType.Byte ) )
             {
-                createAttribute = seq[ "BuiltInType" ];
-                if( createAttribute == null )
+                byte builtInTypeByte = (byte)val.Value;
+                string builtInTypeName = Enum.GetName( typeof( BuiltInType ), builtInTypeByte );
+
+                string path = BuildLibraryReference( ATLPrefix, MetaModelName, "BuiltInType" );
+                CAEXObject builtInTypeObject = m_cAEXDocument.FindByPath( path );
+                AttributeFamilyType attributeDefinition = builtInTypeObject as AttributeFamilyType;
+
+
+                if( attributeDefinition != null )
                 {
-                    createAttribute = seq.Append( "BuiltInType" );
+                    createAttribute = seq[ "BuiltInType" ];
+                    if( createAttribute == null )
+                    {
+                        createAttribute = seq.Append( "BuiltInType" );
+                    }
+
+                    createAttribute.RecreateAttributeInstance( attributeDefinition );
+                    createAttribute.Name = "BuiltInType";
+                    createAttribute.Value = builtInTypeName;
+                    createAttribute.AttributeDataType = "xs:string";
                 }
-
-                createAttribute.RecreateAttributeInstance( attributeDefinition );
-                createAttribute.Name = "BuiltInType";
-                createAttribute.Value = builtInTypeName;
-                createAttribute.AttributeDataType = "xs:string";
             }
-
             return createAttribute;
         }
 

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -186,6 +186,8 @@ namespace MarkdownProcessor
 
             foreach (var modelInfo in MyModelInfoList)
             {
+                Debug.WriteLine( modelName + " Model Info [" + modelInfo.NamespaceUri + "]" );
+
                 AttributeTypeLibType atl = null;
                 InterfaceClassLibType icl = null;
                 RoleClassLibType rcl = null;
@@ -1356,9 +1358,10 @@ namespace MarkdownProcessor
         {
             AttributeType attributeType = null;
 
-            if( val.TypeInfo != null )
+            if( val.TypeInfo != null && val.TypeInfo.BuiltInType == BuiltInType.Int32 )
             {
                 int enumerationValue = -1;
+
                 if( val.TypeInfo.ValueRank == ValueRanks.Scalar )
                 {
                     enumerationValue = (int)val.Value;
@@ -2103,11 +2106,9 @@ namespace MarkdownProcessor
             return createdPathName;
         }
 
-        private string EqualizeParentNodeId(UAInstance node)
+        private string EqualizeParentNodeId(UAInstance node,  string parentNodeId)
         {
-            string parentNodeId = node.ParentNodeId;
-
-            string[] parentSplit = node.ParentNodeId.Split(";");
+            string[] parentSplit = parentNodeId.Split(";");
             if ( parentSplit.Length > 1)
             {
                 ModelInfo modelInfo = m_modelManager.FindModel(node.DecodedNodeId);
@@ -2125,11 +2126,38 @@ namespace MarkdownProcessor
             if (pathName.Length == 0)
             {
                 UAInstance uaInstance = node as UAInstance;
-                if (uaInstance != null)
+                if (uaInstance != null  )
                 {
-                    if (uaInstance.ParentNodeId.Length > 0)
+                    string parentNodeIdString = string.Empty;
+
+                    if ( uaInstance.ParentNodeId != null )
                     {
-                        string parentNodeId = EqualizeParentNodeId(uaInstance);
+                        parentNodeIdString = uaInstance.ParentNodeId;
+                    }
+                    else
+                    {
+                        var refList = m_modelManager.FindReferences( node.DecodedNodeId );
+                        int reversePropertyCount = 0;
+                        foreach( var reference in refList )
+                        {
+                            if( reference.IsForward == false && 
+                                ( reference.ReferenceTypeId.Equals(HasPropertyNodeId) ||
+                                reference.ReferenceTypeId.Equals( Opc.Ua.ReferenceTypeIds.HasComponent ) ) )
+                            {
+                                UANode parentNodeId = m_modelManager.FindNode<UANode>( reference.TargetId );
+                                if ( parentNodeId != null )
+                                {
+                                    parentNodeIdString = parentNodeId.NodeId;
+                                }
+
+                                reversePropertyCount++;
+                            }
+                        }
+                    }
+
+                    if ( parentNodeIdString.Length > 0)
+                    {
+                        string parentNodeId = EqualizeParentNodeId(uaInstance, parentNodeIdString);
                         UANode parentNode = FindNode<NodeSet.UANode>(new NodeId(parentNodeId));
                         pathName = GetCreatedPathName(parentNode);
                     }

--- a/Program.cs
+++ b/Program.cs
@@ -27,10 +27,16 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+
+// Disabling this define allows the program to bypass the try/catch
+// for better debugging error scenarios
+#define ENABLE_PROGRAM_EXCEPTION
+
 using System;
 using System.IO;
 using System.Collections.Generic;
 using MarkdownProcessor;
+
 
 namespace Opc2Aml
 {
@@ -111,7 +117,11 @@ namespace Opc2Aml
         static void Main(string[] args)
         {
             Console.WriteLine("Opc2Aml ...");
+
+
+#if (ENABLE_PROGRAM_EXCEPTION)
             try
+#endif
             {
                 Program program = new Program();
 
@@ -139,7 +149,8 @@ namespace Opc2Aml
                 } 
                 Console.WriteLine("... completed successfully.");
             }
-           
+
+#if ENABLE_PROGRAM_EXCEPTION
             catch (Exception ex)
             {
                 Console.WriteLine("** FATAL EXCEPTION **");
@@ -150,8 +161,8 @@ namespace Opc2Aml
                 Environment.Exit(1);
                 
             }
-    
- 
+#endif    
+
         }
     }
 }


### PR DESCRIPTION
Check the Variant TypeInfo for valid values to cast to Enumeration variant values

If ParentNodeId attribute does not exist, look at reverse references to attempt to find the ParentNodeId.  This is necessary to create unique IDs.