### PR TITLE
Issue 67 - Allow IsAbstract to write false values

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -600,8 +600,6 @@ namespace MarkdownProcessor
                 {
                     if (name == "ValueRank" && val == -2 )
                         return null;
-                    if (name == "IsAbstract" && val == false)
-                        return null;
                     if (name == "IsSource" && val == false)
                         return null;
                     if (name == "Symmetric" && val == false)

--- a/SystemTest/TestAttributes.cs
+++ b/SystemTest/TestAttributes.cs
@@ -40,8 +40,8 @@ namespace SystemTest
             true, DisplayName = "Object Method Expect Description")]
         [DataRow("Description", "7001", "", false, DisplayName = "Object Method No Description")]
         [DataRow("IsAbstract", "2782", "true", true, true, DisplayName = "ConditionType should be Abstract")]
-        [DataRow("IsAbstract", "2881", "", 
-            false, true, DisplayName = "AcknowledgeableConditionType should not be Abstract")]
+        [DataRow("IsAbstract", "2881", "false", 
+            true, true, DisplayName = "AcknowledgeableConditionType should not be Abstract")]
 
         public void TestAttribute(string attribute, string nodeId, 
             string expected, bool expectedToBeFound, bool foundationRoot = false)


### PR DESCRIPTION
False IsAbstract attributes were being deliberately blocked from objects.  The are now allowed to address [Issue 67](https://github.com/OPCF-Members/Opc2Aml/issues/67)