### PR TITLE
feat: Add linux ci build

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz
-          path: ./
+          path: ./Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz
           retention-days: 21
           if-no-files-found: error
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -42,12 +42,14 @@ jobs:
           retention-days: 21
           if-no-files-found: error
 
+      - name: zip release artifacts
+        if: github.event_name == 'release'
+        run:
+          tar -czvf release.tar.gz ./bin/Release/net6.0/
+
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./bin/Release/Opc2Aml.dll
-            ./bin/Release/Opc2Aml.deps.json
-            ./bin/Release/Opc2Aml.pdb
-            ./bin/Release/app.config.json
+            ./release.tar.gz

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -34,20 +34,19 @@ jobs:
       - name: Build dll
         run: dotnet build -c Release  
 
-      - name: Upload artifact
+      - name: Pack artifacts
+        run:
+          tar -czvf Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz -C ./Opc2AmlConsole/bin/Release/net6.0/ .
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dll_version-${{env.BUILD_VERSION}}
-          path: ./bin/Release
+          name: Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz
+          path: ./
           retention-days: 21
           if-no-files-found: error
 
-      - name: zip release artifacts
-        if: github.event_name == 'release'
-        run:
-          tar -czvf Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz ./bin/Release/net6.0/
-
-      - name: Upload to Release
+      - name: Upload on release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -16,7 +16,7 @@ defaults:
 
 env:
   CONAN_DRIVECONTROLLER_REMOTE_URL: https://global-artifacts.se.com/artifactory/api/conan/drivecontroller-conan-prod-fed
-  VERSION: ${{ github.event.release.tag_name || format('{0}{1}', 'temporary-build-', github.run_number) }}
+  BUILD_VERSION: ${{ github.event.release.tag_name || format('{0}{1}', 'temporary-build-', github.run_number) }}
 
 jobs:
   build-linux:
@@ -37,7 +37,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dll_version-${{env.VERSION}}
+          name: dll_version-${{env.BUILD_VERSION}}
           path: ./bin/Release
           retention-days: 21
           if-no-files-found: error

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -45,11 +45,11 @@ jobs:
       - name: zip release artifacts
         if: github.event_name == 'release'
         run:
-          tar -czvf release.tar.gz ./bin/Release/net6.0/
+          tar -czvf Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz ./bin/Release/net6.0/
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./release.tar.gz
+            ./Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz
-          path: ./Opc2Aml.binaries.${{env.BUILD_VERSION}}.tar.gz
+          name: Opc2Aml.binaries.${{env.BUILD_VERSION}}
+          path: ./Opc2AmlConsole/bin/Release/net6.0/
           retention-days: 21
           if-no-files-found: error
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,53 @@
+name: Build - Linux
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  push:
+    branches:
+      - "main" 
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CONAN_DRIVECONTROLLER_REMOTE_URL: https://global-artifacts.se.com/artifactory/api/conan/drivecontroller-conan-prod-fed
+  VERSION: ${{ github.event.release.tag_name || format('{0}{1}', 'temporary-build-', github.run_number) }}
+
+jobs:
+  build-linux:
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 30
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:6.0
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build dll
+        run: dotnet build -c Release  
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dll_version-${{env.VERSION}}
+          path: ./bin/Release
+          retention-days: 21
+          if-no-files-found: error
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./bin/Release/Opc2Aml.dll
+            ./bin/Release/Opc2Aml.deps.json
+            ./bin/Release/Opc2Aml.pdb
+            ./bin/Release/app.config.json


### PR DESCRIPTION
Adds CI build for linux, based on github runner.

Adds Opc2AmlConsole to temporary build as build result, like you can see [here](https://github.com/florian-hubertSE/Opc2Aml/actions/runs/11911660177). Keeps temporary builds for 21 days.

Adds Opc2AmlConsole also to release, if created, like you can see [here](https://github.com/florian-hubertSE/Opc2Aml/releases/tag/0.0.3).

Uses git tag automatically, as version used.