### PR TITLE
Address Issue 85 - Convertor should support arrays for DisplayName and Description

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -586,21 +586,93 @@ namespace MarkdownProcessor
                 uriatt.Value = myuri;
             }
 
-            if (uanode.DisplayName != null &&
-                uanode.DisplayName.Length > 0 &&
-                uanode.DisplayName[0].Value != uanode.DecodedBrowseName.Name)
+            if ( uanode.BrowseName.Equals( "1:Test_ConnectorType" ) )
             {
-                AddModifyAttribute(seq, "DisplayName", "LocalizedText",
-                    uanode.DisplayName[0].Value);
+                bool gonnaWait = true;
             }
 
-            if (uanode.Description != null &&
-                uanode.Description.Length > 0 &&
-                uanode.Description[0].Value.Length > 0)
+            if( uanode.DisplayName != null )
             {
-                AddModifyAttribute(seq, "Description", "LocalizedText",
-                    uanode.Description[0].Value);
+                if ( uanode.DisplayName.Length > 1 )
+                {
+                    List<string> names = new List<string>();
+                    foreach( NodeSet.LocalizedText lt in uanode.DisplayName)
+                    {
+                        names.Add(lt.Value);
+                    }
+
+                    AddModifyAttribute( seq, "DisplayName", "LocalizedText",
+                        new Variant(names), bListOf:true );
+
+                    AttributeType displayNameAttribute = seq[ "DisplayName" ];
+                    if ( displayNameAttribute != null )
+                    {
+                        for( int index = 0; index < uanode.DisplayName.Length; index++ )
+                        {
+                            if ( !String.IsNullOrEmpty( uanode.DisplayName[ index ].Locale ) )
+                            {
+                                AttributeType indexed = displayNameAttribute.Attribute[ index.ToString() ];
+                                if( indexed != null )
+                                {
+                                    AddModifyAttribute( indexed.Attribute, "Locale", "String",
+                                        uanode.DisplayName[ index ].Locale );
+                                }
+                            }
+                        }
+
+                    }
+                }
+                else if( uanode.DisplayName.Length > 0 &&
+                    uanode.DisplayName[ 0 ].Value != uanode.DecodedBrowseName.Name )
+                {
+                    AddModifyAttribute( seq, "DisplayName", "LocalizedText",
+                        uanode.DisplayName[ 0 ].Value );
+                }
             }
+
+            if( uanode.Description != null )
+            {
+                if ( uanode.Description.Length > 1 )
+                {
+                    AttributeType descriptionAttribute = AddModifyAttribute( seq, "Description", "LocalizedText",
+                        new Variant(), bListOf: true );
+
+                    if( descriptionAttribute != null )
+                    {
+                        for( int index = 0; index < uanode.Description.Length; index++ )
+                        {
+                            AttributeType indexed = AddModifyAttribute( 
+                                descriptionAttribute.Attribute, index.ToString(), "LocalizedText",
+                                new Variant() );
+
+                            if( indexed != null )
+                            {
+                                AddModifyAttribute( indexed.Attribute, "Value", "String",
+                                    uanode.Description[ index ].Value );
+                                if( !String.IsNullOrEmpty( uanode.Description[ index ].Locale ) )
+                                {
+                                    AddModifyAttribute( indexed.Attribute, "Locale", "String",
+                                        uanode.Description[ index ].Locale );
+                                }
+                            }
+                        }
+                    }
+                }
+                else if( uanode.Description.Length > 0 &&
+                    uanode.Description[ 0 ].Value.Length > 0 )
+                {
+                    AddModifyAttribute( seq, "Description", "LocalizedText",
+                        uanode.Description[ 0 ].Value );
+                }
+            }
+
+            //if( uanode.Description != null &&
+            //    uanode.Description.Length > 0 &&
+            //    uanode.Description[0].Value.Length > 0)
+            //{
+            //    AddModifyAttribute(seq, "Description", "LocalizedText",
+            //        uanode.Description[0].Value);
+            //}
 
             UAType uaType = uanode as UAType;
             if (  uaType != null && uaType.IsAbstract )

--- a/Opc2AmlConsole/Properties/launchSettings.json
+++ b/Opc2AmlConsole/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Opc2AmlConsole": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "--Nodeset TestAml.xml"
     }
   }
 }

--- a/SystemTest/NodeSetFiles/TestAml.xml
+++ b/SystemTest/NodeSetFiles/TestAml.xml
@@ -2132,7 +2132,8 @@
         </References>
     </UAObject>
     <UAVariable DataType="Int32" ValueRank="1" NodeId="ns=1;i=6126" ArrayDimensions="10" BrowseName="1:OneDimension" ParentNodeId="ns=1;i=5011" UserAccessLevel="3" AccessLevel="3">
-        <DisplayName>OneDimension</DisplayName>
+        <DisplayName>OneDimensionArray</DisplayName>
+        <Description>A One Dimensional Array</Description>
         <References>
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5011</Reference>
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
@@ -2153,7 +2154,10 @@
         </Value>
     </UAVariable>
     <UAVariable DataType="Int32" ValueRank="2" NodeId="ns=1;i=6127" ArrayDimensions="2,5" BrowseName="1:TwoDimensions" ParentNodeId="ns=1;i=5011" UserAccessLevel="3" AccessLevel="3">
-        <DisplayName>TwoDimensions</DisplayName>
+        <DisplayName>TwoDimensionArray</DisplayName>
+        <DisplayName>aTwoDimensionalArray</DisplayName>
+        <Description>A Different Two Dimension Array </Description>
+        <Description>Another Two Dimension Array </Description>
         <References>
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5011</Reference>
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
@@ -2174,7 +2178,10 @@
         </Value>
     </UAVariable>
     <UAVariable DataType="Int32" ValueRank="5" NodeId="ns=1;i=6128" ArrayDimensions="2,2,2,2,2" BrowseName="1:FiveDimensions" ParentNodeId="ns=1;i=5011" UserAccessLevel="3" AccessLevel="3">
-        <DisplayName>FiveDimensions</DisplayName>
+        <DisplayName Locale="en">FiveDimensionArray</DisplayName>
+        <Description Locale="fr">A Five DimensionArray</Description>
+        <Description>Another Five Dimension Array </Description>
+
         <References>
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5011</Reference>
             <Reference ReferenceType="HasTypeDefinition">i=63</Reference>

--- a/SystemTest/NodeSetFiles/TestAml.xml
+++ b/SystemTest/NodeSetFiles/TestAml.xml
@@ -3107,11 +3107,6 @@
             <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
         </References>
-        <Value>
-            <uax:LocalizedText>
-                <uax:Text>Attributes do not have display name or description</uax:Text>
-            </uax:LocalizedText>
-        </Value>
     </UAVariable>
 
     <UAVariable NodeId="ns=1;i=6228" BrowseName="1:SingleLocalizedText" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >

--- a/SystemTest/NodeSetFiles/TestAml.xml
+++ b/SystemTest/NodeSetFiles/TestAml.xml
@@ -3100,13 +3100,122 @@
             </uax:ExtensionObject>
         </Value>
     </UAVariable>
+    <UAObject SymbolicName="LocalizedTextAttributes" NodeId="ns=1;i=5024" BrowseName="1:LocalizedTextAttributes" ParentNodeId="i=85">
+        <DisplayName>Localized Text Attributes</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+        </References>
+    </UAObject>
 
+    <UAVariable NodeId="ns=1;i=6227" BrowseName="1:NoLocalizedText" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Text>Attributes do not have display name or description</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
 
+    <UAVariable NodeId="ns=1;i=6228" BrowseName="1:SingleLocalizedText" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <DisplayName>Single Localized Text</DisplayName>
+        <Description>A Single Description with no Locale</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Text>Attributes have display name and description, but no Locale</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
+
+    <UAVariable NodeId="ns=1;i=6229" BrowseName="1:SingleLocalizedTextLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <DisplayName Locale="en">Single Localized Text with Locale</DisplayName>
+        <Description Locale="en">A Single Description with a Locale</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Locale>en</uax:Locale>
+                <uax:Text>Attributes have display name and description with a single Locale</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
+
+    <UAVariable NodeId="ns=1;i=6230" BrowseName="1:MultipleFirstNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <DisplayName>First DisplayName with no Locale</DisplayName>
+        <Description>First Description with no Locale</Description>
+        <DisplayName Locale="en">Second DisplayName with a Locale</DisplayName>
+        <Description Locale="en">Second Description with a Locale</Description>
+        <DisplayName Locale="fr">Troisième texte localisé avec paramètres régionaux</DisplayName>
+        <Description Locale="fr">Troisième description avec un paramètre régional</Description>
+        <DisplayName Locale="de">Letzter lokalisierter Text mit Gebietsschema</DisplayName>
+        <Description Locale="de">Letzte Beschreibung mit einem Gebietsschema</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Locale>en</uax:Locale>
+                <uax:Text>Multiple DisplayNames and Descriptions, first without a Locale</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
+
+    <UAVariable NodeId="ns=1;i=6231" BrowseName="1:MultipleLastNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <DisplayName Locale="en">First DisplayName with a Locale</DisplayName>
+        <Description Locale="en">First Description with a Locale</Description>
+        <DisplayName Locale="fr">Deuxième DisplayName avec une locale</DisplayName>
+        <Description Locale="fr">Deuxième description avec une locale</Description>
+        <DisplayName Locale="de">Dritter DisplayName mit einem Gebietsschema</DisplayName>
+        <Description Locale="de">Dritte Beschreibung mit einem Gebietsschema</Description>
+        <DisplayName>Last DisplayName with no Locale</DisplayName>
+        <Description>Last Description with no Locale</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Locale>en</uax:Locale>
+                <uax:Text>Multiple DisplayNames and Descriptions, last without a Locale</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
+
+    <UAVariable NodeId="ns=1;i=6231" BrowseName="1:MultipleLastNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+        <DisplayName>First DisplayName with no Locale</DisplayName>
+        <Description>First Description with no Locale</Description>
+        <DisplayName>Second DisplayName with no Locale</DisplayName>
+        <Description>Second Description with no Locale</Description>
+        <DisplayName>Third DisplayName with no Locale</DisplayName>
+        <Description>Third Description with no Locale</Description>
+        <DisplayName>Last DisplayName with no Locale</DisplayName>
+        <Description>Last Description with no Locale</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition" BrowseName="PropertyType">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
+        </References>
+        <Value>
+            <uax:LocalizedText>
+                <uax:Text>Multiple DisplayNames and Descriptions, all without a Locale</uax:Text>
+            </uax:LocalizedText>
+        </Value>
+    </UAVariable>
+    
     <!-- Next Numbers
     ObjectType 1009
     VariableType 2001
     DataType 3004
-    Object 5024
-    Variable 6227
+    Object 5025
+    Variable 6232
     -->
 </UANodeSet>

--- a/SystemTest/NodeSetFiles/TestAml.xml
+++ b/SystemTest/NodeSetFiles/TestAml.xml
@@ -242,7 +242,13 @@
         </References>
     </UAVariable>
     <UAObjectType NodeId="ns=1;i=1007" BrowseName="1:Test_ConnectorType">
-        <DisplayName Locale="en">Test Connector Type Display Name</DisplayName>
+        <Description>Multiple Descriptions</Description>
+        <Description Locale="en">Multiple Descriptions with Locale</Description>
+        <Description Locale="fr">Descriptions multiples avec paramètres régionaux</Description>
+        <Description Locale="de">Mehrere Beschreibungen mit Gebietsschema</Description>
+        <DisplayName>Test Connector Type Display Name</DisplayName>
+        <DisplayName Locale="fr">Type de connecteur de test Nom d'affichage</DisplayName>
+        <DisplayName Locale="de">Anzeigename des Teststeckertyps</DisplayName>
         <References>
             <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
             <Reference ReferenceType="HasProperty">ns=1;i=6014</Reference>

--- a/SystemTest/NodeSetFiles/TestAml.xml
+++ b/SystemTest/NodeSetFiles/TestAml.xml
@@ -242,13 +242,7 @@
         </References>
     </UAVariable>
     <UAObjectType NodeId="ns=1;i=1007" BrowseName="1:Test_ConnectorType">
-        <Description>Multiple Descriptions</Description>
-        <Description Locale="en">Multiple Descriptions with Locale</Description>
-        <Description Locale="fr">Descriptions multiples avec paramètres régionaux</Description>
-        <Description Locale="de">Mehrere Beschreibungen mit Gebietsschema</Description>
-        <DisplayName>Test Connector Type Display Name</DisplayName>
-        <DisplayName Locale="fr">Type de connecteur de test Nom d'affichage</DisplayName>
-        <DisplayName Locale="de">Anzeigename des Teststeckertyps</DisplayName>
+        <DisplayName Locale="en">Test Connector Type Display Name</DisplayName>
         <References>
             <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
             <Reference ReferenceType="HasProperty">ns=1;i=6014</Reference>
@@ -3149,7 +3143,7 @@
         </Value>
     </UAVariable>
 
-    <UAVariable NodeId="ns=1;i=6230" BrowseName="1:MultipleFirstNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+    <UAVariable NodeId="ns=1;i=6230" BrowseName="1:MultipleFirstNoLocale" DataType="LocalizedText" ValueRank="1" ArrayDimensions="1" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
         <DisplayName>First DisplayName with no Locale</DisplayName>
         <Description>First Description with no Locale</Description>
         <DisplayName Locale="en">Second DisplayName with a Locale</DisplayName>
@@ -3163,14 +3157,23 @@
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
         </References>
         <Value>
-            <uax:LocalizedText>
-                <uax:Locale>en</uax:Locale>
-                <uax:Text>Multiple DisplayNames and Descriptions, first without a Locale</uax:Text>
-            </uax:LocalizedText>
+            <uax:ListOfLocalizedText>
+                <uax:LocalizedText>
+                    <uax:Text>Multiple</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Locale>en</uax:Locale>
+                    <uax:Text>DisplayNames and Descriptions</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Locale>en</uax:Locale>
+                    <uax:Text>first without a locale</uax:Text>
+                </uax:LocalizedText>
+            </uax:ListOfLocalizedText>
         </Value>
     </UAVariable>
 
-    <UAVariable NodeId="ns=1;i=6231" BrowseName="1:MultipleLastNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+    <UAVariable NodeId="ns=1;i=6231" BrowseName="1:MultipleLastNoLocale" DataType="LocalizedText" ValueRank="1" ArrayDimensions="1" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
         <DisplayName Locale="en">First DisplayName with a Locale</DisplayName>
         <Description Locale="en">First Description with a Locale</Description>
         <DisplayName Locale="fr">Deuxième DisplayName avec une locale</DisplayName>
@@ -3184,14 +3187,23 @@
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
         </References>
         <Value>
-            <uax:LocalizedText>
-                <uax:Locale>en</uax:Locale>
-                <uax:Text>Multiple DisplayNames and Descriptions, last without a Locale</uax:Text>
-            </uax:LocalizedText>
+            <uax:ListOfLocalizedText>
+                <uax:LocalizedText>
+                    <uax:Locale>en</uax:Locale>
+                    <uax:Text>Multiple</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Locale>en</uax:Locale>
+                    <uax:Text>DisplayNames and Descriptions</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Text>last without a locale</uax:Text>
+                </uax:LocalizedText>
+            </uax:ListOfLocalizedText>
         </Value>
     </UAVariable>
 
-    <UAVariable NodeId="ns=1;i=6231" BrowseName="1:MultipleLastNoLocale" DataType="LocalizedText" ValueRank="-1" ArrayDimensions="" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
+    <UAVariable NodeId="ns=1;i=6232" BrowseName="1:MultipleNoLocale" DataType="LocalizedText" ValueRank="1" ArrayDimensions="1" ParentNodeId="ns=1;i=5024" UserAccessLevel="3" AccessLevel="3" >
         <DisplayName>First DisplayName with no Locale</DisplayName>
         <Description>First Description with no Locale</Description>
         <DisplayName>Second DisplayName with no Locale</DisplayName>
@@ -3205,9 +3217,17 @@
             <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5024</Reference>
         </References>
         <Value>
-            <uax:LocalizedText>
-                <uax:Text>Multiple DisplayNames and Descriptions, all without a Locale</uax:Text>
-            </uax:LocalizedText>
+            <uax:ListOfLocalizedText>
+                <uax:LocalizedText>
+                    <uax:Text>Multiple</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Text>DisplayNames and Descriptions</uax:Text>
+                </uax:LocalizedText>
+                <uax:LocalizedText>
+                    <uax:Text>all without a locale</uax:Text>
+                </uax:LocalizedText>
+            </uax:ListOfLocalizedText>
         </Value>
     </UAVariable>
     

--- a/SystemTest/TestLocalizedText.cs
+++ b/SystemTest/TestLocalizedText.cs
@@ -1,0 +1,159 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Aml.Engine.AmlObjects;
+using Aml.Engine.CAEX;
+using Aml.Engine.CAEX.Extensions;
+using Opc.Ua;
+using static System.Net.Mime.MediaTypeNames;
+
+
+namespace SystemTest
+{
+    [TestClass]
+    public class TestLocalizedText
+    {
+        CAEXDocument m_document = null;
+
+        #region Tests
+
+        [TestMethod]
+        [DataRow( "DisplayName", DisplayName = "No LocalizedText DisplayName" )]
+        [DataRow( "Description", DisplayName = "No LocalizedText Description" )]
+        public void NoLocalizedText( string attributeName )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( "6227" );
+            AttributeType attributeType = objectToTest.Attribute[ attributeName ];
+            Assert.IsNull( attributeType, "Unexpected attribute found for " + attributeName );
+        }
+
+
+        [TestMethod]
+        [DataRow("6228", "DisplayName", "", "Single Localized Text", 
+            DisplayName = "Single no Locale DisplayName")]
+        [DataRow( "6228", "Description", "", "A Single Description with no Locale",
+            DisplayName = "Single no Locale Description" )]
+        [DataRow( "6229", "DisplayName", "en", "Single Localized Text with Locale",
+            DisplayName = "Single with Locale DisplayName" )]
+        [DataRow( "6229", "Description", "en", "A Single Description with a Locale",
+            DisplayName = "Single with Locale Description" )]
+        public void SingleLocalizedText(string nodeId, string attributeName, string localeId, string text )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( nodeId );
+            AttributeType attributeType = ValidateAttribute( objectToTest.Attribute, attributeName, text );
+
+            if( string.IsNullOrEmpty( localeId ) )
+            {
+                Assert.AreEqual( 0, attributeType.Attribute.Count, 1 );
+            }
+            else
+            {
+                ValidateAttribute( attributeType.Attribute, localeId, text );
+            }
+        }
+
+        [TestMethod]
+        [DataRow( "6230", "DisplayName", 
+            new string[] { "qaa", "en", "fr", "de"},
+            new string[] { 
+                "First DisplayName with no Locale",
+                "Second DisplayName with a Locale", 
+                "Troisième texte localisé avec paramètres régionaux", 
+                "Letzter lokalisierter Text mit Gebietsschema" },
+            DisplayName = "Multiple Starting with no Locale DisplayName" )]
+        [DataRow( "6230", "Description",
+            new string[] { "qaa", "en", "fr", "de" },
+            new string[] {
+                "First Description with no Locale",
+                "Second Description with a Locale",
+                "Troisième description avec un paramètre régional",
+                "Letzte Beschreibung mit einem Gebietsschema" },
+            DisplayName = "Multiple Starting with no Locale Description" )]
+        [DataRow( "6231", "DisplayName",
+            new string[] { "en", "fr", "de", "qaa"},
+            new string[] {
+                "First DisplayName with a Locale",
+                "Deuxième DisplayName avec une locale",
+                "Dritter DisplayName mit einem Gebietsschema",
+                "Last DisplayName with no Locale" },
+            DisplayName = "Multiple Ending with no Locale DisplayName" )]
+        [DataRow( "6231", "Description",
+            new string[] { "en", "fr", "de", "qaa" },
+            new string[] {
+                "First Description with a Locale",
+                "Deuxième description avec une locale",
+                "Dritte Beschreibung mit einem Gebietsschema",
+                "Last Description with no Locale" },
+            DisplayName = "Multiple Ending with no Locale Description" )]
+        
+        
+        [DataRow( "6232", "DisplayName",
+            new string[] { "qaa", "qab", "qac", "qad" },
+            new string[] {
+                "First DisplayName with no Locale",
+                "Second DisplayName with no Locale",
+                "Third DisplayName with no Locale",
+                "Last DisplayName with no Locale" },
+            DisplayName = "Multiple no Locale DisplayName" )]
+        [DataRow( "6232", "Description",
+            new string[] { "qaa", "qab", "qac", "qad" },
+            new string[] {
+                "First Description with no Locale",
+                "Second Description with no Locale",
+                "Third Description with no Locale",
+                "Last Description with no Locale" },
+            DisplayName = "Multiple no Locale Description" )]
+        public void MultipleLocalizedText( string nodeId, string attributeName, string[] localeId, string[] text )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( nodeId );
+            AttributeType topLevel = ValidateAttribute( objectToTest.Attribute, attributeName, text[ 0 ] );
+            AttributeType textLevel = ValidateAttribute( topLevel.Attribute, localeId[0], text[ 0 ] );
+
+            for( int index = 0; index < localeId.Length; index++ )
+            {
+                string subLocale = "aml-lang=" + localeId[ index ];  
+                ValidateAttribute( textLevel.Attribute, subLocale, text[index] );
+            }
+        }
+
+        private AttributeType ValidateAttribute( AttributeSequence sequence, string attributeName, string attributeValue )
+        {
+            Assert.IsNotNull( sequence, "AttributeSequence not found" );
+            AttributeType attributeType = sequence[ attributeName ];
+            Assert.IsNotNull( attributeType, attributeName + " attribute not found" );
+            Assert.IsNotNull( attributeType.Value, attributeName + " attribute valid not found" );
+            Assert.AreEqual( attributeValue, attributeType.Value, "Unexpected value for " + attributeName );
+            return attributeType;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "TestAml.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
+
+        public SystemUnitClassType GetTestObject(string nodeId, bool foundationRoot = false)
+        {
+            CAEXDocument document = GetDocument();
+            string rootName = TestHelper.GetRootName();
+            if ( foundationRoot )
+            {
+                rootName = TestHelper.GetOpcRootName();
+            }
+            CAEXObject initialObject = document.FindByID(rootName + nodeId);
+            Assert.IsNotNull(initialObject, "Unable to find Initial Object");
+            SystemUnitClassType theObject = initialObject as SystemUnitClassType;
+            Assert.IsNotNull(theObject, "Unable to Cast Initial Object");
+            return theObject;
+        }
+
+        #endregion
+    }
+}

--- a/SystemTest/TestLocalizedText.cs
+++ b/SystemTest/TestLocalizedText.cs
@@ -17,6 +17,78 @@ namespace SystemTest
         #region Tests
 
         [TestMethod]
+        public void TestNoValue( )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( "6227" );
+            AttributeType attributeType = objectToTest.Attribute[ "Value" ];
+            Assert.IsNotNull( attributeType );
+            Assert.IsNull( attributeType.Value, "Unexpected Value found" );
+        }
+
+        [TestMethod]
+        [DataRow( "6228", "", "Attributes have display name and description, but no Locale",
+            DisplayName = "Single value no Locale" )]
+        [DataRow( "6229", "en", "Attributes have display name and description with a single Locale",
+            DisplayName = "Single value with Locale" )]
+        public void TestScalarValue( string node, string locale, string text )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( node );
+            AttributeType value = ValidateAttribute( objectToTest.Attribute, "Value", text );
+
+            if( string.IsNullOrEmpty( locale ) )
+            {
+                Assert.AreEqual( 0, value.Attribute.Count );
+            }
+            else
+            {
+                ValidateAttribute( value.Attribute, locale, text );
+            }
+        }
+
+        [TestMethod]
+        [DataRow( "6230", new string[] { "", "en", "en"  },
+            new string[] {
+                "Multiple",
+                "DisplayNames and Descriptions",
+                "first without a locale" },
+            DisplayName = "Multiple Starting with no Locale" )]
+
+        [DataRow( "6231", new string[] { "en", "en", "" },
+            new string[] {
+                "Multiple",
+                "DisplayNames and Descriptions",
+                "last without a locale" },
+            DisplayName = "Multiple Ending with no Locale" )]
+
+        [DataRow( "6232", new string[] { "", "", "" },
+            new string[] {
+                "Multiple",
+                "DisplayNames and Descriptions",
+                "all without a locale" },
+            DisplayName = "Multiple all without no Locale" )]
+
+        public void TestArrayValue( string node, string[] locales, string[] values )
+        {
+            SystemUnitClassType objectToTest = GetTestObject( node );
+            AttributeType attributeType = objectToTest.Attribute[ "Value" ];
+            Assert.IsNotNull( attributeType );
+            Assert.IsNull( attributeType.Value, "Unexpected Value found" );
+
+            for( int index = 0; index < locales.Length; index++ )
+            {
+                AttributeType indexed = ValidateAttribute( attributeType.Attribute, index.ToString(), values[ index ] );
+                if( string.IsNullOrEmpty( locales[ index ] ) )
+                {
+                    Assert.AreEqual( 0, indexed.Attribute.Count, "Unexpected Locale found" );
+                }
+                else
+                {
+                    ValidateAttribute( indexed.Attribute, locales[ index ], values[ index ] );
+                }
+            }
+        }
+
+        [TestMethod]
         [DataRow( "DisplayName", DisplayName = "No LocalizedText DisplayName" )]
         [DataRow( "Description", DisplayName = "No LocalizedText Description" )]
         public void NoLocalizedText( string attributeName )


### PR DESCRIPTION
Follows the [Aml Specification for Multilingual expressions in AutomationML](https://www.automationml.org/wp-content/uploads/2021/06/BPR_002E_Multilingual_Expressions_Oct2014.pdf)

Also supported locales for LocalizedText Variables