### PR TITLE
93 update libraries

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -158,6 +158,7 @@ namespace MarkdownProcessor
 
         public void CreateAML(string modelPath, string modelName = null)
         {
+            DateTime startTime = DateTime.Now;
             string modelUri = m_modelManager.LoadModel(modelPath, null, null);
             structureNode = m_modelManager.FindNodeByName("Structure");
             if (modelName == null)
@@ -364,6 +365,11 @@ namespace MarkdownProcessor
             container.Close();
 
             Utils.LogInfo( "Amlx Container Created for model " + modelName );
+            DateTime endTime = DateTime.Now;
+            TimeSpan totalTime = endTime - startTime;
+            Utils.LogError( "Total time to create AMLX file: " + totalTime.ToString() );
+
+
 
         }
 

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -368,6 +368,7 @@ namespace MarkdownProcessor
             DateTime endTime = DateTime.Now;
             TimeSpan totalTime = endTime - startTime;
             Utils.LogError( "Total time to create AMLX file: " + totalTime.ToString() );
+            Utils.LogError( "Total time in CreateClassInstance: " + problem.ToString() );
 
 
 
@@ -1693,12 +1694,17 @@ namespace MarkdownProcessor
             AmlExpandedNodeId a = new AmlExpandedNodeId(nodeId, m_modelManager.FindModelUri(nodeId), prefix);
             return a.ToString();
          }
+        TimeSpan problem = new TimeSpan( 0, 0, 0, 0, 0 );
+
 
         private InternalElementType CreateClassInstanceWithIDReplacement(string prefix, SystemUnitFamilyType child)
         {
+            DateTime start = DateTime.Now;
             InternalElementType internalElementType = child.CreateClassInstance();
-            
-            CompareLinksToExternaInterfaces(child, internalElementType);
+            TimeSpan duration = DateTime.Now - start;
+            problem += duration;
+
+            CompareLinksToExternaInterfaces( child, internalElementType);
 
             InternalElementSequence originalInternalElements = child.InternalElement;
             InternalElementSequence createdInternalElements = internalElementType.InternalElement;

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -364,16 +364,10 @@ namespace MarkdownProcessor
             container.AddRoot(m_cAEXDocument.SaveToStream(true), new Uri("/" + internalFileInfo.Name + ".aml", UriKind.Relative));
             container.Close();
 
-            Utils.LogInfo( "Amlx Container Created for model " + modelName );
             DateTime endTime = DateTime.UtcNow;
             TimeSpan totalTime = endTime - startTime;
-            Utils.LogError( "Total time to create AMLX file: " + totalTime.ToString() );
-            double percentage = ( problem.TotalSeconds / totalTime.TotalSeconds ) * 100;
-            Utils.LogError( "Total time in CreateClassInstance: " + problem.ToString() );
-            Utils.LogError( "Percent in CreateClassInstance: " + percentage.ToString( "0.##" ) );
-
-
-
+            Utils.LogInfo( "Amlx Container Created for model " + modelName + 
+                " (Time in creation " + totalTime.ToString() + ")" );
         }
 
         private void AddLibraryHeaderInfo(CAEXBasicObject bo, ModelInfo modelInfo = null)
@@ -1701,15 +1695,10 @@ namespace MarkdownProcessor
             AmlExpandedNodeId a = new AmlExpandedNodeId(nodeId, m_modelManager.FindModelUri(nodeId), prefix);
             return a.ToString();
          }
-        TimeSpan problem = new TimeSpan( 0, 0, 0, 0, 0 );
-
 
         private InternalElementType CreateClassInstanceWithIDReplacement(string prefix, SystemUnitFamilyType child)
         {
-            DateTime start = DateTime.UtcNow;
             InternalElementType internalElementType = child.CreateClassInstance();
-            TimeSpan duration = DateTime.UtcNow - start;
-            problem += duration;
 
             CompareLinksToExternaInterfaces( child, internalElementType);
 

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -262,7 +262,13 @@ namespace MarkdownProcessor
                         AddLibraryHeaderInfo(atl as CAEXBasicObject, modelInfo);
                     }
 
-                    atl.AttributeType.Insert( dicEntry.Value, false);  // insert into the AML document in alpha order
+                    AttributeFamilyType created = atl.AttributeType.Insert( dicEntry.Value, false);  // insert into the AML document in alpha order
+
+                    Utils.LogError( "Entry Name {0} ID {1}, Created Name {2} ID {3} ",
+                        dicEntry.Value.Name,
+                        dicEntry.Value.ID,
+                        created.Name,
+                        created.ID);
                 }
 
                 foreach( var dicEntry in SortedDataTypes)  // cteate the ListOf versions

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -846,11 +846,6 @@ namespace MarkdownProcessor
                         case BuiltInType.Enumeration:
                             {
                                 a.AttributeValue = val;
-                                if( val.TypeInfo.BuiltInType == BuiltInType.XmlElement )
-                                {
-                                    // For consistency with previous versions
-                                    a.AttributeDataType = "";
-                                }
                                 break;
                             }
 

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -158,7 +158,7 @@ namespace MarkdownProcessor
 
         public void CreateAML(string modelPath, string modelName = null)
         {
-            DateTime startTime = DateTime.Now;
+            DateTime startTime = DateTime.UtcNow;
             string modelUri = m_modelManager.LoadModel(modelPath, null, null);
             structureNode = m_modelManager.FindNodeByName("Structure");
             if (modelName == null)
@@ -365,7 +365,7 @@ namespace MarkdownProcessor
             container.Close();
 
             Utils.LogInfo( "Amlx Container Created for model " + modelName );
-            DateTime endTime = DateTime.Now;
+            DateTime endTime = DateTime.UtcNow;
             TimeSpan totalTime = endTime - startTime;
             Utils.LogError( "Total time to create AMLX file: " + totalTime.ToString() );
             double percentage = ( problem.TotalSeconds / totalTime.TotalSeconds ) * 100;
@@ -1701,9 +1701,9 @@ namespace MarkdownProcessor
 
         private InternalElementType CreateClassInstanceWithIDReplacement(string prefix, SystemUnitFamilyType child)
         {
-            DateTime start = DateTime.Now;
+            DateTime start = DateTime.UtcNow;
             InternalElementType internalElementType = child.CreateClassInstance();
-            TimeSpan duration = DateTime.Now - start;
+            TimeSpan duration = DateTime.UtcNow - start;
             problem += duration;
 
             CompareLinksToExternaInterfaces( child, internalElementType);

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -368,7 +368,9 @@ namespace MarkdownProcessor
             DateTime endTime = DateTime.Now;
             TimeSpan totalTime = endTime - startTime;
             Utils.LogError( "Total time to create AMLX file: " + totalTime.ToString() );
+            double percentage = ( problem.TotalSeconds / totalTime.TotalSeconds ) * 100;
             Utils.LogError( "Total time in CreateClassInstance: " + problem.ToString() );
+            Utils.LogError( "Percent in CreateClassInstance: " + percentage.ToString( "0.##" ) );
 
 
 

--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="3.1.1" />
-    <PackageReference Include="Aml.Engine.Resources" Version="3.0.0" />
+    <PackageReference Include="Aml.Engine" Version="4.3.0" />
+    <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />

--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.158" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.375.443" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="Aml.Engine" Version="4.4.0" />
-    <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />

--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="4.3.0" />
+    <PackageReference Include="Aml.Engine" Version="4.4.0" />
     <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -11,14 +11,14 @@
     <PackageReference Include="Aml.Engine" Version="4.4.0" />
     <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Aml.Engine.Services" Version="4.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.158" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.375.443" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="4.3.0" />
+    <PackageReference Include="Aml.Engine" Version="4.4.0" />
     <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Aml.Engine.Services" Version="4.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Aml.Engine" Version="4.4.0" />
-    <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
     <PackageReference Include="Aml.Engine.Services" Version="4.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="3.2.1" />
-    <PackageReference Include="Aml.Engine.Resources" Version="3.0.0" />
-    <PackageReference Include="Aml.Engine.Services" Version="3.2.1" />
+    <PackageReference Include="Aml.Engine" Version="4.3.0" />
+    <PackageReference Include="Aml.Engine.Resources" Version="4.1.2" />
+    <PackageReference Include="Aml.Engine.Services" Version="4.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -48,10 +48,9 @@ namespace SystemTest
             TestValue( value, "Guid", "13131313-1313-1313-1313-131313131313", "xs:string" );
             TestValue( value, "ByteString", "MTQxNDE0MTQ=", "xs:base64Binary" );
             
-            string unknownDataType = "";
             TestValue( value, "XmlElement", 
                 "<TheFifteenthElement xmlns=\"http://opcfoundation.org/UA/FX/AML/TESTING/LevelOne/Types.xsd\">Fifteen</TheFifteenthElement>",
-                unknownDataType );
+                "xs:string" );
 
             ValidateNodeId( value, "NodeId", GetUri( 2 ), new NodeId( 16 ) );
             ValidateNodeId( value, "ExpandedNodeId", GetUri( 2 ), new NodeId( 17 ) );

--- a/app.config.json
+++ b/app.config.json
@@ -3,6 +3,6 @@
         "OutputFilePath": "Opc2Aml.report.txt",
         "DeleteOnLoad": true,
         // None, Error, Information, Debug
-        "LogLevel": "Error"
+        "LogLevel": "Information"
     }
 }

--- a/app.config.json
+++ b/app.config.json
@@ -3,6 +3,6 @@
         "OutputFilePath": "Opc2Aml.report.txt",
         "DeleteOnLoad": true,
         // None, Error, Information, Debug
-        "LogLevel": "Information"
+        "LogLevel": "Error"
     }
 }


### PR DESCRIPTION
Packages of note:
Aml.Engine upgrade from 3.1.1 to 4.4.0
Aml.Engine.Resources was removed, as Aml.Engine already includes it.
OPCFoundation.NetStandard.Opc.Ua upgrade from 1.5.374.158 to 1.5.375.443

Aml.Engine 4.4.0 required several changes
Insert function now has an asIs parameter, so as to not change the CAEXObject ID.
RoleClasses now require a separate ID than similar SystemUnitClasses, so an 'rc' prefix was added.

Various SystemTest packages were also upgraded.