### PR TITLE
94 improper browse name uri

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -564,14 +564,15 @@ namespace MarkdownProcessor
             // only set the value if different from the base node
             string baseuri = "";
             if (basenode != null )
-              baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedNodeId.NamespaceIndex].NamespaceUri;
-            string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedNodeId.NamespaceIndex].NamespaceUri;
+              baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
+            string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
 
             var nodeId = seq["NodeId"];
 
             if (uanode.DecodedNodeId.IsNullNodeId == false)
             {
-                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.DecodedNodeId, myuri);
+                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.DecodedNodeId,
+                    m_modelManager.ModelNamespaceIndexes[uanode.DecodedNodeId.NamespaceIndex].NamespaceUri);
                 Variant variant = new Variant(expandedNodeId);
                 nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
             }

--- a/SystemTest/NodeSetFiles/AmlFxTest.xml
+++ b/SystemTest/NodeSetFiles/AmlFxTest.xml
@@ -4,14 +4,16 @@
         <Uri>http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/</Uri>
         <Uri>http://opcfoundation.org/UA/FX/AC/</Uri>
         <Uri>http://opcfoundation.org/UA/FX/Data/</Uri>
-    </NamespaceUris>
+		<Uri>http://opcfoundation.org/UA/DI/</Uri>
+	</NamespaceUris>
     <Models>
         <Model ModelUri="http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/">
             <RequiredModel ModelUri="http://opcfoundation.org/UA/FX/AC/" />
         </Model>
     </Models>
     <Aliases>
-        <Alias Alias="Organizes">i=35</Alias>
+		<Alias Alias="LocalizedText">i=21</Alias>
+		<Alias Alias="Organizes">i=35</Alias>
         <Alias Alias="HasTypeDefinition">i=40</Alias>
         <Alias Alias="HasProperty">i=46</Alias>
         <Alias Alias="HasComponent">i=47</Alias>
@@ -77,7 +79,23 @@
             <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5003</Reference>
         </References>
     </UAObject>
-    <UAMethod ParentNodeId="ns=1;i=5003" NodeId="ns=1;i=7001" BrowseName="2:CloseConnections" MethodDeclarationId="ns=2;i=293">
+
+	<UAObject NodeId="ns=1;i=5008" BrowseName="1:AnAsset" ParentNodeId="ns=1;i=5004">
+		<DisplayName>AnAsset</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5004</Reference>
+			<Reference ReferenceType="HasTypeDefinition">ns=2;i=3</Reference>
+		</References>
+	</UAObject>
+	<UAVariable DataType="LocalizedText" NodeId="ns=1;i=6008" BrowseName="4:Manufacturer" ParentNodeId="ns=1;i=5008" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>Manufacturer</DisplayName>
+		<References>
+			<Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5008</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+		</References>
+	</UAVariable>
+
+	<UAMethod ParentNodeId="ns=1;i=5003" NodeId="ns=1;i=7001" BrowseName="2:CloseConnections" MethodDeclarationId="ns=2;i=293">
         <DisplayName>CloseConnections</DisplayName>
         <References>
             <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5003</Reference>

--- a/SystemTest/TestNamespaceUriAttributes.cs
+++ b/SystemTest/TestNamespaceUriAttributes.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using Aml.Engine.AmlObjects;
+using Aml.Engine.CAEX;
+using Aml.Engine.CAEX.Extensions;
+using Opc.Ua;
+
+
+namespace SystemTest
+{
+    [TestClass]
+    public class TestNamespaceUriAttributes
+    {
+        // Test is to address issue 94 - 
+        // The Namespaces of BrowseNames differ between the generated AML file and the original Nodeset file.
+        // Test Both NodeId NamespaceUris and BrowseNameUris
+
+        private const string FxIdPrefix = "nsu%3Dhttp%3A%2F%2Fopcfoundation.org%2FUA%2FFX%2FAC%2F%3Bi%3D";
+        private const string AmlFxTestPrefix = "nsu%3Dhttp%3A%2F%2Fopcfoundation.org%2FUA%2FFX%2FAML%2FTESTING%2FAmlFxTest%2F%3Bi%3D";
+        public const string TestAmlUri = "http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/";
+        private const string FxAcUri = "http://opcfoundation.org/UA/FX/AC/";
+        private const string DiUri = "http://opcfoundation.org/UA/DI/";
+
+        CAEXDocument m_document = null;
+
+        #region Tests
+
+        [TestMethod, Timeout( TestHelper.UnitTestTimeout )]
+        [DataRow( false, "3", FxAcUri, DisplayName = "FxAssetType" )]
+        [DataRow( false, "175", FxAcUri, DisplayName = "Manufacturer" )]
+        [DataRow( true, "5008", TestAmlUri, DisplayName = "Asset Instance" )]
+        [DataRow( true, "6008", TestAmlUri, DisplayName = "Manufacturer Instance")]
+        public void TestNodeIds( bool instance, string nodeIdentifier, string expectedUri)
+        {
+            SystemUnitClassType objectToTest = GetTestObject( instance, nodeIdentifier );
+            AttributeType nodeId = objectToTest.Attribute[ "NodeId" ];
+            Assert.IsNotNull( nodeId );
+            AttributeType rootNodeId = nodeId.Attribute[ "RootNodeId" ];
+            Assert.IsNotNull( rootNodeId );
+            AttributeType namespaceUri = rootNodeId.Attribute[ "NamespaceUri" ];
+            Assert.IsNotNull( namespaceUri );
+            Assert.AreEqual( expectedUri, namespaceUri.Value );
+
+            AttributeType identifier = rootNodeId.Attribute[ "NumericId" ];
+            Assert.IsNotNull( identifier );
+            Assert.AreEqual( nodeIdentifier, identifier.Value );
+        }
+
+        [TestMethod, Timeout(TestHelper.UnitTestTimeout)]
+        [DataRow(false, "3", FxAcUri, DisplayName = "FxAssetType")]
+        [DataRow(false, "175", DiUri, DisplayName = "Manufacturer")]
+        [DataRow(true, "5008", TestAmlUri, DisplayName = "Asset Instance")]
+        [DataRow(true, "6008", DiUri, DisplayName = "Manufacturer Instance")]
+        public void TestBrowseNames(bool instance, string nodeIdentifier, string expectedUri)
+        {
+            SystemUnitClassType objectToTest = GetTestObject(instance, nodeIdentifier);
+            AttributeType browseName = objectToTest.Attribute["BrowseName"];
+            Assert.IsNotNull(browseName);
+            AttributeType namespaceUri = browseName.Attribute["NamespaceURI"];
+            Assert.IsNotNull(namespaceUri);
+            Assert.AreEqual(expectedUri, namespaceUri.Value);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "AmlFxTest.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
+
+        public SystemUnitClassType GetTestObject(bool instance, string nodeId)
+        {
+            CAEXDocument document = GetDocument();
+
+            string rootName = FxIdPrefix;
+            if ( instance )
+            {
+                rootName = AmlFxTestPrefix;
+            }
+            CAEXObject initialObject = document.FindByID(rootName + nodeId);
+            Assert.IsNotNull(initialObject, "Unable to find Initial Object");
+            SystemUnitClassType theObject = initialObject as SystemUnitClassType;
+            Assert.IsNotNull(theObject, "Unable to Cast Initial Object");
+            return theObject;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Solution for Issue 94 - The Namespaces of BrowseNames differ between the generated AML file and the original Nodeset file