### PR TITLE
Namespace Uri Issues

### DIFF
--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -564,14 +564,15 @@ namespace MarkdownProcessor
             // only set the value if different from the base node
             string baseuri = "";
             if (basenode != null )
-              baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedNodeId.NamespaceIndex].NamespaceUri;
-            string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedNodeId.NamespaceIndex].NamespaceUri;
+              baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
+            string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
 
             var nodeId = seq["NodeId"];
 
             if (uanode.DecodedNodeId.IsNullNodeId == false)
             {
-                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.DecodedNodeId, myuri);
+                ExpandedNodeId expandedNodeId = new ExpandedNodeId(uanode.DecodedNodeId,
+                    m_modelManager.ModelNamespaceIndexes[uanode.DecodedNodeId.NamespaceIndex].NamespaceUri);
                 Variant variant = new Variant(expandedNodeId);
                 nodeId = AddModifyAttribute(seq, "NodeId", "NodeId", variant);
             }

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -590,7 +590,7 @@ namespace MarkdownProcessor
             // Ensure that NamespaceUri is always present
             AttributeType uriAttribute = browse.Attribute["NamespaceUri"];
             uriAttribute.Value = 
-                m_modelManager.ModelNamespaceIndexes[uanode.DecodedNodeId.NamespaceIndex].NamespaceUri;
+                m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
 
 
             // Remove the name for everything

--- a/NodeSetToAML.cs
+++ b/NodeSetToAML.cs
@@ -563,14 +563,8 @@ namespace MarkdownProcessor
             AddLibraryHeaderInfo( suc_meta as CAEXBasicObject);
         }
 
-        private void AddBaseNodeClassAttributes( AttributeSequence seq, UANode uanode, UANode basenode = null)
+        private void AddBaseNodeClassAttributes( AttributeSequence seq, UANode uanode)
         {
-            // only set the value if different from the base node
-            string baseuri = "";
-            if (basenode != null )
-              baseuri = m_modelManager.ModelNamespaceIndexes[basenode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
-            string myuri = m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
-
             var nodeId = seq["NodeId"];
 
             if (uanode.DecodedNodeId.IsNullNodeId == false)
@@ -587,19 +581,17 @@ namespace MarkdownProcessor
                 browse = AddModifyAttribute(seq, "BrowseName", "QualifiedName", Variant.Null);
             }
 
-            // Ensure that NamespaceUri is always present
+            // Ensure that NamespaceUri is always present #100
             AttributeType uriAttribute = browse.Attribute["NamespaceUri"];
             uriAttribute.Value = 
                 m_modelManager.ModelNamespaceIndexes[uanode.DecodedBrowseName.NamespaceIndex].NamespaceUri;
 
-
-            // Remove the name for everything
+            // Remove the name for everything #100
             AttributeType nameSubAttribute = browse.Attribute["Name"];
             if (nameSubAttribute != null)
             {
                 browse.Attribute.RemoveElement(nameSubAttribute);
             }
-
 
             BuildLocalizedTextAttribute( seq, "DisplayName", uanode.DisplayName, 
                 uanode.DecodedBrowseName.Name, ignoreEqual: true );
@@ -2393,7 +2385,7 @@ namespace MarkdownProcessor
                     // override any attribute values
 
                     var basenode = FindNode<NodeSet.UANode>(BaseNodeId);
-                    AddBaseNodeClassAttributes(rtn.Attribute, refnode, basenode);
+                    AddBaseNodeClassAttributes(rtn.Attribute, refnode);
                     switch (refnode.NodeClass)
                     {
                         case NodeClass.ObjectType:
@@ -2481,7 +2473,7 @@ namespace MarkdownProcessor
                                 rtn.AddInstance(ie);
 
                                 var basenode = FindNode<NodeSet.UANode>(TypeDefNodeId);                               
-                                AddBaseNodeClassAttributes(ie.Attribute, targetNode, basenode);
+                                AddBaseNodeClassAttributes(ie.Attribute, targetNode);
                                 if (targetNode.NodeClass == NodeClass.Variable)
                                 {  //  Set the datatype for Value
                                     var varnode = targetNode as NodeSet.UAVariable;

--- a/SystemTest/NodeSetFiles/AmlFxTest.xml
+++ b/SystemTest/NodeSetFiles/AmlFxTest.xml
@@ -4,14 +4,16 @@
         <Uri>http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/</Uri>
         <Uri>http://opcfoundation.org/UA/FX/AC/</Uri>
         <Uri>http://opcfoundation.org/UA/FX/Data/</Uri>
-    </NamespaceUris>
+		<Uri>http://opcfoundation.org/UA/DI/</Uri>
+	</NamespaceUris>
     <Models>
         <Model ModelUri="http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/">
             <RequiredModel ModelUri="http://opcfoundation.org/UA/FX/AC/" />
         </Model>
     </Models>
     <Aliases>
-        <Alias Alias="Organizes">i=35</Alias>
+		<Alias Alias="LocalizedText">i=21</Alias>
+		<Alias Alias="Organizes">i=35</Alias>
         <Alias Alias="HasTypeDefinition">i=40</Alias>
         <Alias Alias="HasProperty">i=46</Alias>
         <Alias Alias="HasComponent">i=47</Alias>
@@ -77,7 +79,23 @@
             <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5003</Reference>
         </References>
     </UAObject>
-    <UAMethod ParentNodeId="ns=1;i=5003" NodeId="ns=1;i=7001" BrowseName="2:CloseConnections" MethodDeclarationId="ns=2;i=293">
+
+	<UAObject NodeId="ns=1;i=5008" BrowseName="1:AnAsset" ParentNodeId="ns=1;i=5004">
+		<DisplayName>AnAsset</DisplayName>
+		<References>
+			<Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5004</Reference>
+			<Reference ReferenceType="HasTypeDefinition">ns=2;i=3</Reference>
+		</References>
+	</UAObject>
+	<UAVariable DataType="LocalizedText" NodeId="ns=1;i=6008" BrowseName="4:Manufacturer" ParentNodeId="ns=1;i=5008" UserAccessLevel="3" AccessLevel="3">
+		<DisplayName>Manufacturer</DisplayName>
+		<References>
+			<Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5008</Reference>
+			<Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+		</References>
+	</UAVariable>
+
+	<UAMethod ParentNodeId="ns=1;i=5003" NodeId="ns=1;i=7001" BrowseName="2:CloseConnections" MethodDeclarationId="ns=2;i=293">
         <DisplayName>CloseConnections</DisplayName>
         <References>
             <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5003</Reference>

--- a/SystemTest/TestAttributes.cs
+++ b/SystemTest/TestAttributes.cs
@@ -71,7 +71,7 @@ namespace SystemTest
             AttributeType browseNameAttribute = objectToTest.Attribute[ "BrowseName" ];
             Assert.IsNotNull( browseNameAttribute );
 
-            AttributeType namespaceUriAttribute = browseNameAttribute.Attribute[ "NamespaceURI" ];
+            AttributeType namespaceUriAttribute = browseNameAttribute.Attribute[ "NamespaceUri" ];
             Assert.IsNotNull( namespaceUriAttribute );
             Assert.AreEqual( "xs:anyURI", namespaceUriAttribute.AttributeDataType );
 

--- a/SystemTest/TestComplexNonRootNamespace.cs
+++ b/SystemTest/TestComplexNonRootNamespace.cs
@@ -638,7 +638,7 @@ namespace SystemTest
         {
             AttributeType qualifiedNameAttribute = GetAttribute( attribute, name, validateSubAttributes: true );
             AttributeType nameAttribute = GetAttribute( qualifiedNameAttribute, "Name", validateSubAttributes: false );
-            AttributeType namespaceUriAttribute = GetAttribute( qualifiedNameAttribute, "NamespaceURI", validateSubAttributes: false );
+            AttributeType namespaceUriAttribute = GetAttribute( qualifiedNameAttribute, "NamespaceUri", validateSubAttributes: false );
 
             Assert.AreEqual( uri, namespaceUriAttribute.Value );
             Assert.AreEqual( "xs:anyURI", namespaceUriAttribute.AttributeDataType );

--- a/SystemTest/TestComplexRootNamespace.cs
+++ b/SystemTest/TestComplexRootNamespace.cs
@@ -309,7 +309,7 @@ namespace SystemTest
         {
             AttributeType qualifiedNameAttribute = GetAttribute( attribute, name, validateSubAttributes: true );
             AttributeType nameAttribute = GetAttribute( qualifiedNameAttribute, "Name", validateSubAttributes: false );
-            AttributeType namespaceUriAttribute = GetAttribute( qualifiedNameAttribute, "NamespaceURI", validateSubAttributes: false );
+            AttributeType namespaceUriAttribute = GetAttribute( qualifiedNameAttribute, "NamespaceUri", validateSubAttributes: false );
 
             Assert.AreEqual( uri, namespaceUriAttribute.Value );
             Assert.AreEqual( "xs:anyURI", namespaceUriAttribute.AttributeDataType );

--- a/SystemTest/TestDataTypes.cs
+++ b/SystemTest/TestDataTypes.cs
@@ -27,7 +27,7 @@ namespace SystemTest
         [DataRow( "6192", "2023-09-13T14:39:08-06:00", "xs:dateTime", "SourceTimestamp", DisplayName = "SourceTimestamp" )]
 
         [DataRow( "6191", "d23c82b6-1715-4951-acd1-84fb898d6b6c", "xs:string", DisplayName = "Guid" )]
-        [DataRow( "6190", "http://opcfoundation.org/UA/FX/AML/TESTING", "xs:anyURI", "NamespaceURI", DisplayName = "Qualified NamespaceURI" )]
+        [DataRow( "6190", "http://opcfoundation.org/UA/FX/AML/TESTING", "xs:anyURI", "NamespaceUri", DisplayName = "Qualified NamespaceUri" )]
         [DataRow( "6190", "MyQualifiedName", "xs:string", "Name", DisplayName = "Qualified Name" )]
 
         [DataRow( "6139", "StringNodeId", "xs:string", "RootNodeId", "StringId", DisplayName = "NodeId String" )]

--- a/SystemTest/TestMultiDimensionalArray.cs
+++ b/SystemTest/TestMultiDimensionalArray.cs
@@ -89,7 +89,7 @@ namespace SystemTest
             AttributeType browseNameAttribute = objectToTest.Attribute[ "BrowseName" ];
             Assert.IsNotNull( browseNameAttribute );
 
-            AttributeType namespaceUriAttribute = browseNameAttribute.Attribute[ "NamespaceURI" ];
+            AttributeType namespaceUriAttribute = browseNameAttribute.Attribute[ "NamespaceUri" ];
             Assert.IsNotNull( namespaceUriAttribute );
             Assert.AreEqual( "xs:anyURI", namespaceUriAttribute.AttributeDataType );
 

--- a/SystemTest/TestNamespaceUriAttributes.cs
+++ b/SystemTest/TestNamespaceUriAttributes.cs
@@ -57,7 +57,7 @@ namespace SystemTest
             SystemUnitClassType objectToTest = GetTestObject(instance, nodeIdentifier);
             AttributeType browseName = objectToTest.Attribute["BrowseName"];
             Assert.IsNotNull(browseName);
-            AttributeType namespaceUri = browseName.Attribute["NamespaceURI"];
+            AttributeType namespaceUri = browseName.Attribute["NamespaceUri"];
             Assert.IsNotNull(namespaceUri);
             Assert.AreEqual(expectedUri, namespaceUri.Value);
         }

--- a/SystemTest/TestNamespaceUriAttributes.cs
+++ b/SystemTest/TestNamespaceUriAttributes.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using Aml.Engine.AmlObjects;
+using Aml.Engine.CAEX;
+using Aml.Engine.CAEX.Extensions;
+using Opc.Ua;
+
+
+namespace SystemTest
+{
+    [TestClass]
+    public class TestNamespaceUriAttributes
+    {
+        // Test is to address issue 94 - 
+        // The Namespaces of BrowseNames differ between the generated AML file and the original Nodeset file.
+        // Test Both NodeId NamespaceUris and BrowseNameUris
+
+        private const string FxIdPrefix = "nsu%3Dhttp%3A%2F%2Fopcfoundation.org%2FUA%2FFX%2FAC%2F%3Bi%3D";
+        private const string AmlFxTestPrefix = "nsu%3Dhttp%3A%2F%2Fopcfoundation.org%2FUA%2FFX%2FAML%2FTESTING%2FAmlFxTest%2F%3Bi%3D";
+        public const string TestAmlUri = "http://opcfoundation.org/UA/FX/AML/TESTING/AmlFxTest/";
+        private const string FxAcUri = "http://opcfoundation.org/UA/FX/AC/";
+        private const string DiUri = "http://opcfoundation.org/UA/DI/";
+
+        CAEXDocument m_document = null;
+
+        #region Tests
+
+        [TestMethod, Timeout( TestHelper.UnitTestTimeout )]
+        [DataRow( false, "3", FxAcUri, DisplayName = "FxAssetType" )]
+        [DataRow( false, "175", FxAcUri, DisplayName = "Manufacturer" )]
+        [DataRow( true, "5008", TestAmlUri, DisplayName = "Asset Instance" )]
+        [DataRow( true, "6008", TestAmlUri, DisplayName = "Manufacturer Instance")]
+        public void TestNodeIds( bool instance, string nodeIdentifier, string expectedUri)
+        {
+            SystemUnitClassType objectToTest = GetTestObject( instance, nodeIdentifier );
+            AttributeType nodeId = objectToTest.Attribute[ "NodeId" ];
+            Assert.IsNotNull( nodeId );
+            AttributeType rootNodeId = nodeId.Attribute[ "RootNodeId" ];
+            Assert.IsNotNull( rootNodeId );
+            AttributeType namespaceUri = rootNodeId.Attribute[ "NamespaceUri" ];
+            Assert.IsNotNull( namespaceUri );
+            Assert.AreEqual( expectedUri, namespaceUri.Value );
+
+            AttributeType identifier = rootNodeId.Attribute[ "NumericId" ];
+            Assert.IsNotNull( identifier );
+            Assert.AreEqual( nodeIdentifier, identifier.Value );
+        }
+
+        [TestMethod, Timeout(TestHelper.UnitTestTimeout)]
+        [DataRow(false, "3", FxAcUri, DisplayName = "FxAssetType")]
+        [DataRow(false, "175", DiUri, DisplayName = "Manufacturer")]
+        [DataRow(true, "5008", TestAmlUri, DisplayName = "Asset Instance")]
+        [DataRow(true, "6008", DiUri, DisplayName = "Manufacturer Instance")]
+        public void TestBrowseNames(bool instance, string nodeIdentifier, string expectedUri)
+        {
+            SystemUnitClassType objectToTest = GetTestObject(instance, nodeIdentifier);
+            AttributeType browseName = objectToTest.Attribute["BrowseName"];
+            Assert.IsNotNull(browseName);
+            AttributeType namespaceUri = browseName.Attribute["NamespaceURI"];
+            Assert.IsNotNull(namespaceUri);
+            Assert.AreEqual(expectedUri, namespaceUri.Value);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private CAEXDocument GetDocument()
+        {
+            if( m_document == null )
+            {
+                m_document = TestHelper.GetReadOnlyDocument( "AmlFxTest.xml.amlx" );
+            }
+            Assert.IsNotNull( m_document, "Unable to retrieve Document" );
+            return m_document;
+        }
+
+        public SystemUnitClassType GetTestObject(bool instance, string nodeId)
+        {
+            CAEXDocument document = GetDocument();
+
+            string rootName = FxIdPrefix;
+            if ( instance )
+            {
+                rootName = AmlFxTestPrefix;
+            }
+            CAEXObject initialObject = document.FindByID(rootName + nodeId);
+            Assert.IsNotNull(initialObject, "Unable to find Initial Object");
+            SystemUnitClassType theObject = initialObject as SystemUnitClassType;
+            Assert.IsNotNull(theObject, "Unable to Cast Initial Object");
+            return theObject;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Resolves 
92 Attribute NamespaceUri is used in different variations and should be unified
94 The Namespaces of BrowseNames differ between the generated AML file and the original Nodeset file
100 NamespaceURI of a BrowseName of SUCs is handled differently across different Libraries