### PR TITLE
126 role requirements

### DIFF
--- a/Opc2Aml.csproj
+++ b/Opc2Aml.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="4.4.0" />
+    <PackageReference Include="Aml.Engine" Version="4.4.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />

--- a/SystemTest/InternalElements.cs
+++ b/SystemTest/InternalElements.cs
@@ -300,6 +300,52 @@ namespace SystemTest
             }
         }
 
+        [TestMethod, Timeout(TestHelper.UnitTestTimeout)]
+        public void TestInstanceRoleRequirements()
+        {
+            var document = GetDocument();
+
+            foreach (InstanceHierarchyType instanceHierarchy in document.CAEXFile.InstanceHierarchy)
+            {
+                foreach (InternalElementType internalElement in instanceHierarchy.InternalElement)
+                {
+                    CheckRoleRequirementsRecursive(internalElement);
+                }
+            }
+        }
+
+        [TestMethod, Timeout(TestHelper.UnitTestTimeout)]
+        public void TestRoleRequirements()
+        {
+            var document = GetDocument();
+
+            foreach (SystemUnitClassLibType libType in document.CAEXFile.SystemUnitClassLib)
+            {
+                foreach (SystemUnitClassType systemUnitClass in libType)
+                {
+                    CheckRoleRequirementsRecursive(systemUnitClass);
+                }
+            }
+        }
+
+        private void CheckRoleRequirementsRecursive(SystemUnitClassType entity)
+        {
+            var seen = new HashSet<string>();
+
+            foreach (IObjectWithRoleReference roleReference in entity.RoleReferences)
+            {
+                // Use RefBaseRoleClassPath as the unique key for duplication
+                string key = roleReference.RoleReference ?? string.Empty;
+                Assert.IsFalse(seen.Contains(key), $"Duplicate RoleRequirements '{key}' found in '{entity.Name}'");
+                seen.Add(key);
+            }
+
+            foreach (InternalElementType internalElement in entity.InternalElement)
+            {
+                CheckRoleRequirementsRecursive(internalElement);
+            }
+        }
+
 
         #endregion
 

--- a/SystemTest/SystemTest.csproj
+++ b/SystemTest/SystemTest.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="4.4.0" />
-    <PackageReference Include="Aml.Engine.Services" Version="4.2.2" />
+    <PackageReference Include="Aml.Engine" Version="4.4.3" />
+    <PackageReference Include="Aml.Engine.Services" Version="4.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />


### PR DESCRIPTION
Role Requirements were duplicated in the AmlEngine 4.4.0

Updating to the most recent 4.4.3 AmlEngine removes the issue.