### PR TITLE
139 invalid parent node

### DIFF
--- a/SystemTest/TestNonHierarchical.cs
+++ b/SystemTest/TestNonHierarchical.cs
@@ -67,6 +67,12 @@ namespace SystemTest
             TestHelper.Uris.AmlFxTest, 5008u,
             DisplayName = "Instance Hosts")]
 
+        [DataRow("", TestHelper.Uris.Root, 14156u,
+            "HasCondition",
+            TestHelper.Uris.Root, Opc.Ua.ObjectTypes.CertificateExpirationAlarmType,
+            DisplayName = "DefaultApplication Group to Audit Event Issue 139")]
+
+
         public void TestReference(string prefix, TestHelper.Uris testUri, uint testNodeId, string referenceName,
             TestHelper.Uris targetUri, uint targetNodeId)
         {


### PR DESCRIPTION
Found source of crash reported in issue 139.

ModelManager UANode ParentNodeId is a text field, and is not adjusted for all the namespaces.
Removed the reliance on ParentNodeId, and instead looked for the proper reverse reference to find the parent, which has been adjusted for all namespaces.

Original thought that the Nodeset Namespace Indexes were created out of order is incorrect, the ModelManager handles them correctly.